### PR TITLE
[FEAT/#13] 회원 탈퇴 및 탈퇴 사유 수집 기능 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
@@ -1,0 +1,28 @@
+package com.example.picknwhip_be.domain.report.controller;
+
+import com.example.picknwhip_be.domain.report.dto.req.ReportRequestDTO;
+import com.example.picknwhip_be.domain.report.service.ReportCommandService;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Report", description = "신고 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reports")
+public class ReportRestController {
+
+  private final ReportCommandService reportCommandService;
+
+  @Operation(summary = "신고하기 API", description = "로그인된 사용자가 신고를 접수합니다.")
+  @PostMapping("")
+  public ApiResponse<String> createReport(@RequestBody ReportRequestDTO.CreateReportDTO request) {
+    // TODO: SecurityContext 연동 필요
+    Long userId = 1L;
+    reportCommandService.createReport(userId, request);
+    return ApiResponse.of(GeneralSuccessCode.OK, "신고가 접수되었습니다.");
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/converter/ReportConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/converter/ReportConverter.java
@@ -1,0 +1,17 @@
+package com.example.picknwhip_be.domain.report.converter;
+
+import com.example.picknwhip_be.domain.report.dto.req.ReportRequestDTO;
+import com.example.picknwhip_be.domain.report.entity.Report;
+import com.example.picknwhip_be.domain.user.entity.User;
+
+public class ReportConverter {
+  public static Report toReport(ReportRequestDTO.CreateReportDTO request, User reporter) {
+    return Report.builder()
+        .reporter(reporter)
+        .shopId(request.getShopId())
+        .targetType(request.getTargetType())
+        .reasonType(request.getReasonType())
+        .content(request.getContent())
+        .build();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/dto/req/ReportRequestDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/dto/req/ReportRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.picknwhip_be.domain.report.dto.req;
+
+import com.example.picknwhip_be.domain.report.entity.ReportReasonType;
+import com.example.picknwhip_be.domain.report.entity.ReportTargetType;
+import lombok.Getter;
+
+public class ReportRequestDTO {
+
+  @Getter
+  public static class CreateReportDTO {
+    private Long shopId;
+    private ReportTargetType targetType;
+    private ReportReasonType reasonType;
+    private String content;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/entity/Report.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/entity/Report.java
@@ -1,0 +1,34 @@
+package com.example.picknwhip_be.domain.report.entity;
+
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Report extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long reportId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "reporter_id")
+  private User reporter;
+
+  private Long shopId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ReportTargetType targetType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ReportReasonType reasonType;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/entity/ReportReasonType.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/entity/ReportReasonType.java
@@ -1,0 +1,11 @@
+package com.example.picknwhip_be.domain.report.entity;
+
+public enum ReportReasonType {
+  NOT_USED_OFTEN,
+  USE_OTHER_SERVICE,
+  QUALITY_NOT_SATISFIED,
+  EXPENSIVE_PRICE,
+  INCONVENIENT_SERVICE,
+  PRIVACY_CONCERN,
+  OTHER
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/entity/ReportTargetType.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.report.entity;
+
+public enum ReportTargetType {
+  SHOP,
+  REVIEW,
+  CHAT
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/exception/ReportException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/exception/ReportException.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.report.exception;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+
+public class ReportException extends GeneralException {
+  public ReportException(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/exception/code/ReportErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/exception/code/ReportErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.picknwhip_be.domain.report.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReportErrorCode implements BaseErrorCode {
+  REPORT_FAILED(HttpStatus.BAD_REQUEST, "REPORT400_1", "신고 처리에 실패했습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/repository/ReportRepository.java
@@ -1,0 +1,6 @@
+package com.example.picknwhip_be.domain.report.repository;
+
+import com.example.picknwhip_be.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {}

--- a/src/main/java/com/example/picknwhip_be/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/service/ReportCommandService.java
@@ -1,0 +1,8 @@
+package com.example.picknwhip_be.domain.report.service;
+
+import com.example.picknwhip_be.domain.report.dto.req.ReportRequestDTO;
+import com.example.picknwhip_be.domain.report.entity.Report;
+
+public interface ReportCommandService {
+  Report createReport(Long userId, ReportRequestDTO.CreateReportDTO request);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/service/ReportCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/service/ReportCommandServiceImpl.java
@@ -1,0 +1,35 @@
+package com.example.picknwhip_be.domain.report.service;
+
+import com.example.picknwhip_be.domain.report.converter.ReportConverter;
+import com.example.picknwhip_be.domain.report.dto.req.ReportRequestDTO;
+import com.example.picknwhip_be.domain.report.entity.Report;
+import com.example.picknwhip_be.domain.report.repository.ReportRepository;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportCommandServiceImpl implements ReportCommandService {
+
+  private final ReportRepository reportRepository;
+  private final UserQueryService userQueryService;
+
+  @Override
+  public Report createReport(Long userId, ReportRequestDTO.CreateReportDTO request) {
+    User reporter = userQueryService.getUser(userId);
+    /*
+     * [TODO: 검색 기능 연동]
+     * 1. 현재 신고 대상이 '케이크샵(SHOP)'인 경우, 프론트엔드에서 가게명 검색 기능을 통해
+     * 리스트에서 선택된 정확한 shopId가 넘어오는 구조입니다.
+     * 2. 현재 검색 기능이 미구현 상태이므로, 전달받은 shopId의 유효성 검증 로직은
+     * 검색 API 파트 개발 완료 후 연동할 예정
+     */
+
+    Report newReport = ReportConverter.toReport(request, reporter);
+    return reportRepository.save(newReport);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/UserWithdrawal.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/UserWithdrawal.java
@@ -1,0 +1,24 @@
+package com.example.picknwhip_be.domain.user.entity;
+
+import com.example.picknwhip_be.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserWithdrawal extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long withdrawalId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Column(columnDefinition = "TEXT")
+  private String feedback;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/WithdrawalReason.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/WithdrawalReason.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.user.entity;
+
+public enum WithdrawalReason {
+  NOT_USED_OFTEN,
+  EXPENSIVE_PRICE,
+  LACK_OF_DESIGN,
+  INCONVENIENT_SERVICE,
+  APP_ERROR,
+  OTHER
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/WithdrawalReasonItem.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/WithdrawalReasonItem.java
@@ -1,0 +1,23 @@
+package com.example.picknwhip_be.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class WithdrawalReasonItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "withdrawal_id")
+  private UserWithdrawal userWithdrawal;
+
+  @Enumerated(EnumType.STRING)
+  private WithdrawalReason reasonType;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/repository/UserWithdrawalRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/repository/UserWithdrawalRepository.java
@@ -1,0 +1,8 @@
+package com.example.picknwhip_be.domain.user.repository;
+
+import com.example.picknwhip_be.domain.user.entity.UserWithdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserWithdrawalRepository extends JpaRepository<UserWithdrawal, Long> {}

--- a/src/main/java/com/example/picknwhip_be/domain/user/repository/WithdrawalReasonItemRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/repository/WithdrawalReasonItemRepository.java
@@ -1,0 +1,8 @@
+package com.example.picknwhip_be.domain.user.repository;
+
+import com.example.picknwhip_be.domain.user.entity.WithdrawalReasonItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WithdrawalReasonItemRepository extends JpaRepository<WithdrawalReasonItem, Long> {}


### PR DESCRIPTION
## 💡 Issue
- Close #13 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 사용자가 서비스를 탈퇴할 때 사유를 수집하고 계정을 비활성화하는 기능 구현

## 🛠️ Changes
- [x] UserWithdrawal(탈퇴 기록) 및 WithdrawalReasonItem(다중 사유 저장) 엔티티 설계
- [x] 회원 탈퇴 API (POST): /api/users/withdraw 엔드포인트 구현
- [x] Soft Delete 로직: 유저의 status를 WITHDRAWN으로 변경하고 탈퇴 일시를 기록하는 withdraw() 메서드 구현
- [x] 피드백 수집: 기획안에 명시된 6가지 탈퇴 사유(Enum) 및 사용자 직접 입력 피드백(feedback) 저장 기능 추가
- [x] 레포지토리 추가: UserWithdrawalRepository, WithdrawalReasonItemRepository 구현

## 📸 Screenshots

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?