### PR TITLE
[Fix/#19] 포맷팅 자동화 훅 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,17 +55,3 @@ spotless {
 		endWithNewline()
 	}
 }
-
-
-//git hook 설정(spotlessApply 자동화)
-tasks.register('updateGitHooks', Copy) {
-	from new File(rootProject.rootDir, '.github/hooks/pre-commit')
-
-	into { new File(rootProject.rootDir, '.git/hooks') }
-	fileMode 0775
-}
-
-tasks.named('compileJava') {
-	dependsOn 'spotlessApply'  // 컴파일 시 포맷팅 자동 적용
-	dependsOn 'updateGitHooks' // 컴파일 시 훅 파일 최신화
-}


### PR DESCRIPTION
## 💡 Issue
- Close #19 

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [x] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- Git pre-commit 훅과 컴파일 단계에서 Spotless를 강제로 실행하던 자동화 설정을 제거했습니다.
- Windows 환경에서 호환되지 않아 pre-commit 훅 실행 실패로 커밋이 차단되는 이슈를 해결하기 위함입니다.
- 자동화 훅이 OS에 종속되고, 환경에 따라 다르게 동작할 수 있어 PR 단계에서 검증하는 게 낫다고 판단했습니다.
- 포맷팅은 `./gradlew spotlessApply` 명령어로 수동 실행 후 PR을 올리고, CI에서 검증하면 될 것 같습니다.

## 🛠️ Changes
- [x] build.gradle에서 Git 훅 자동 설치(updateGitHooks) 로직 제거
- [x]  compileJava 단계에서 spotlessApply 강제 실행 설정 제거
- [x]  로컬 환경(OS)에 따른 커밋 실패 가능성 제거 및 개발 흐름 안정화

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?