### PR TITLE
[FEAT/#14] 리뷰, 알림 도메인 엔티티 생성

### DIFF
--- a/src/main/java/com/example/picknwhip_be/PicknwhipBeApplication.java
+++ b/src/main/java/com/example/picknwhip_be/PicknwhipBeApplication.java
@@ -2,8 +2,10 @@ package com.example.picknwhip_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PicknwhipBeApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
@@ -1,0 +1,39 @@
+package com.example.picknwhip_be.domain.notification.entity;
+
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "notification")
+@EntityListeners(AuditingEntityListener.class)
+public class Notification extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  //    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  //    @JoinColumn(name = "user_id", nullable = false)
+  //    private User user;
+
+  @Column(name = "type", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private NotificationType type;
+
+  @Column(name = "title", length = 512, nullable = false)
+  private String title;
+
+  @Column(name = "content", nullable = false)
+  private String content;
+
+  @Column(name = "is_read", nullable = false)
+  @Builder.Default
+  private boolean isRead = false;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
@@ -4,7 +4,6 @@ import com.example.picknwhip_be.domain.notification.enums.NotificationType;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
@@ -12,7 +11,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(name = "notification")
-@EntityListeners(AuditingEntityListener.class)
 public class Notification extends BaseEntity {
 
   @Id
@@ -27,10 +25,10 @@ public class Notification extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private NotificationType type;
 
-  @Column(name = "title", length = 512, nullable = false)
+  @Column(name = "title", length = 200, nullable = false)
   private String title;
 
-  @Column(name = "content", nullable = false)
+  @Column(name = "content", length = 200, nullable = false)
   private String content;
 
   @Column(name = "is_read", nullable = false)

--- a/src/main/java/com/example/picknwhip_be/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/enums/NotificationType.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.notification.enums;
+
+public enum NotificationType {
+  ORDER,
+  REVIEW,
+  EVENT
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
@@ -1,16 +1,12 @@
 package com.example.picknwhip_be.domain.review.entity;
 
-import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
-import com.example.picknwhip_be.domain.review.entity.mapping.ReviewReply;
-import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
@@ -18,7 +14,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(name = "review")
-@EntityListeners(AuditingEntityListener.class)
 public class Review extends BaseEntity {
 
   @Id
@@ -51,18 +46,11 @@ public class Review extends BaseEntity {
   private LocalDateTime deletedAt;
 
   @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
-  private List<ReviewImage> images = new ArrayList<>();
-
-  @OneToOne(mappedBy = "review")
-  private ReviewReply reply;
-
-  @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
-  private List<ReviewSelectedKeyword> keywords = new ArrayList<>();
-
-  @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
   private List<ReviewLike> likes = new ArrayList<>();
 
   public void softDelete(LocalDateTime now) {
-    this.deletedAt = now;
+    if (this.deletedAt == null) {
+      this.deletedAt = now;
+    }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
@@ -1,0 +1,68 @@
+package com.example.picknwhip_be.domain.review.entity;
+
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewReply;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "review")
+@EntityListeners(AuditingEntityListener.class)
+public class Review extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  //    @OneToOne(fetch = FetchType.LAZY, optional = false)
+  //    @JoinColumn(name = "order_id", nullable = false, unique = true)
+  //    private Order order;
+
+  //    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  //    @JoinColumn(name = "user_id", nullable = false)
+  //    private User user;
+
+  //    @ManyToOne(fetch = FetchType.LAZY)
+  //    @JoinColumn(name = "shop_id", nullable = false)
+  //    private Shops shops;
+
+  //    @ManyToOne(fetch = FetchType.LAZY)
+  //    @JoinColumn(name = "design_id")
+  //    private DesignGallery design;
+
+  @Column(name = "rating", nullable = false)
+  private Integer rating;
+
+  @Column(name = "content", length = 500, nullable = false)
+  private String content;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
+  private List<ReviewImage> images = new ArrayList<>();
+
+  @OneToOne(mappedBy = "review")
+  private ReviewReply reply;
+
+  @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
+  private List<ReviewSelectedKeyword> keywords = new ArrayList<>();
+
+  @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
+  private List<ReviewLike> likes = new ArrayList<>();
+
+  public void softDelete(LocalDateTime now) {
+    this.deletedAt = now;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewImage.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewImage.java
@@ -1,0 +1,44 @@
+package com.example.picknwhip_be.domain.review.entity.mapping;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(
+    name = "review_image",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_review_image_review_order",
+          columnNames = {"review_id", "sort_order"})
+    })
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewImage extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "review_id", nullable = false)
+  private Review review;
+
+  @Column(name = "s3_key", nullable = false, length = 512)
+  private String s3Key;
+
+  @Column(name = "sort_order", nullable = false)
+  private int sortOrder;
+
+  private LocalDateTime deletedAt;
+
+  public void softDelete(LocalDateTime now) {
+    this.deletedAt = now;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewImage.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewImage.java
@@ -5,21 +5,13 @@ import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Table(
-    name = "review_image",
-    uniqueConstraints = {
-      @UniqueConstraint(
-          name = "uk_review_image_review_order",
-          columnNames = {"review_id", "sort_order"})
-    })
-@EntityListeners(AuditingEntityListener.class)
+@Table(name = "review_image")
 public class ReviewImage extends BaseEntity {
 
   @Id
@@ -36,9 +28,12 @@ public class ReviewImage extends BaseEntity {
   @Column(name = "sort_order", nullable = false)
   private int sortOrder;
 
+  @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
   public void softDelete(LocalDateTime now) {
-    this.deletedAt = now;
+    if (this.deletedAt == null) {
+      this.deletedAt = now;
+    }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewKeyword.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewKeyword.java
@@ -1,0 +1,33 @@
+package com.example.picknwhip_be.domain.review.entity.mapping;
+
+import com.example.picknwhip_be.domain.review.enums.KeywordCategory;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(
+    name = "review_keyword",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_review_keyword_category_keyword",
+          columnNames = {"category", "keyword"})
+    })
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewKeyword {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "category", nullable = false, length = 20)
+  @Enumerated(EnumType.STRING)
+  private KeywordCategory category;
+
+  @Column(name = "keyword", nullable = false, length = 15)
+  private String keyword;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewKeyword.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewKeyword.java
@@ -3,7 +3,6 @@ package com.example.picknwhip_be.domain.review.entity.mapping;
 import com.example.picknwhip_be.domain.review.enums.KeywordCategory;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
@@ -17,7 +16,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
           name = "uk_review_keyword_category_keyword",
           columnNames = {"category", "keyword"})
     })
-@EntityListeners(AuditingEntityListener.class)
 public class ReviewKeyword {
 
   @Id

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
@@ -1,0 +1,43 @@
+package com.example.picknwhip_be.domain.review.entity.mapping;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(
+//    name = "review_like",
+//    uniqueConstraints = {
+//      @UniqueConstraint(
+//          name = "uk_review_like_review_user",
+//          columnNames = {"review_id", "user_id"})
+//    }
+    )
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewLike extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "review_id", nullable = false)
+  private Review review;
+
+  //    @ManyToOne(fetch =  FetchType.LAZY, optional = false)
+  //    @JoinColumn(name = "user_id", nullable = false)
+  //    private User user;
+
+  private LocalDateTime deletedAt;
+
+  public void softDelete(LocalDateTime now) {
+    this.deletedAt = now;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
@@ -19,7 +19,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 //          name = "uk_review_like_review_user",
 //          columnNames = {"review_id", "user_id"})
 //    }
-    )
+)
 @EntityListeners(AuditingEntityListener.class)
 public class ReviewLike extends BaseEntity {
 

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
@@ -3,9 +3,7 @@ package com.example.picknwhip_be.domain.review.entity.mapping;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
@@ -13,14 +11,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(
-//    name = "review_like",
-//    uniqueConstraints = {
-//      @UniqueConstraint(
-//          name = "uk_review_like_review_user",
-//          columnNames = {"review_id", "user_id"})
-//    }
-)
-@EntityListeners(AuditingEntityListener.class)
+    name = "review_like"
+    //    uniqueConstraints = {
+    //      @UniqueConstraint(
+    //          name = "uk_review_like_review_user",
+    //          columnNames = {"review_id", "user_id"})
+    //    }
+    )
 public class ReviewLike extends BaseEntity {
 
   @Id
@@ -34,10 +31,4 @@ public class ReviewLike extends BaseEntity {
   //    @ManyToOne(fetch =  FetchType.LAZY, optional = false)
   //    @JoinColumn(name = "user_id", nullable = false)
   //    private User user;
-
-  private LocalDateTime deletedAt;
-
-  public void softDelete(LocalDateTime now) {
-    this.deletedAt = now;
-  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
@@ -3,8 +3,8 @@ package com.example.picknwhip_be.domain.review.entity.mapping;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Builder

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
@@ -4,7 +4,6 @@ import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
@@ -3,9 +3,9 @@ package com.example.picknwhip_be.domain.review.entity.mapping;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
@@ -19,7 +19,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
           name = "uk_review_reply_review",
           columnNames = {"review_id"})
     })
-@EntityListeners(AuditingEntityListener.class)
 public class ReviewReply extends BaseEntity {
 
   @Id
@@ -37,9 +36,12 @@ public class ReviewReply extends BaseEntity {
   @Column(name = "content", length = 500, nullable = false)
   private String content;
 
+  @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
   public void softDelete(LocalDateTime now) {
-    this.deletedAt = now;
+    if (this.deletedAt == null) {
+      this.deletedAt = now;
+    }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
@@ -1,0 +1,45 @@
+package com.example.picknwhip_be.domain.review.entity.mapping;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(
+    name = "review_reply",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_review_reply_review",
+          columnNames = {"review_id"})
+    })
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewReply extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "review_id", unique = true)
+  private Review review;
+
+  //    @ManyToOne(fetch = FetchType.LAZY)
+  //    @JoinColumn(name = "seller_id")
+  //    private User user;
+
+  @Column(name = "content", length = 500, nullable = false)
+  private String content;
+
+  private LocalDateTime deletedAt;
+
+  public void softDelete(LocalDateTime now) {
+    this.deletedAt = now;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewSelectedKeyword.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewSelectedKeyword.java
@@ -1,0 +1,41 @@
+package com.example.picknwhip_be.domain.review.entity.mapping;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(
+    name = "review_selected_keyword",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_review_keyword",
+          columnNames = {"review_id", "keyword_id"})
+    })
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewSelectedKeyword {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "review_id", nullable = false)
+  private Review review;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "keyword_id", nullable = false)
+  private ReviewKeyword keyword;
+
+  private LocalDateTime deletedAt;
+
+  public void softDelete(LocalDateTime now) {
+    this.deletedAt = now;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewSelectedKeyword.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewSelectedKeyword.java
@@ -2,9 +2,7 @@ package com.example.picknwhip_be.domain.review.entity.mapping;
 
 import com.example.picknwhip_be.domain.review.entity.Review;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
@@ -18,7 +16,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
           name = "uk_review_keyword",
           columnNames = {"review_id", "keyword_id"})
     })
-@EntityListeners(AuditingEntityListener.class)
 public class ReviewSelectedKeyword {
 
   @Id
@@ -32,10 +29,4 @@ public class ReviewSelectedKeyword {
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "keyword_id", nullable = false)
   private ReviewKeyword keyword;
-
-  private LocalDateTime deletedAt;
-
-  public void softDelete(LocalDateTime now) {
-    this.deletedAt = now;
-  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/enums/KeywordCategory.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/enums/KeywordCategory.java
@@ -1,0 +1,9 @@
+package com.example.picknwhip_be.domain.review.enums;
+
+public enum KeywordCategory {
+  DESIGN_SATISFACTION,
+  SAME_AS_RESULT,
+  TASTE,
+  COMMUNICATION,
+  PICKUP
+}

--- a/src/main/java/com/example/picknwhip_be/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/picknwhip_be/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.picknwhip_be.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 💡 Issue
- Close #14 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- API 설계 전 맡은 도메인(리뷰, 알림)의 엔티티를 생성하였습니다.
- 아직 생성되지 않은 다른 도메인의 엔티티를 참조하는 칼럼들은 주석 처리해두었습니다.
- 리뷰에 soft delete를 도입하고자 하여 deletedAt으로 상태를 관리할 수 있게 설계해두었습니다.
- 각 칼럼에 필요한 제약 조건뿐만 아니라, 데이터 중복을 막기 위해 테이블에 복합 유니크 제약 조건을 설정해두었습니다.

## 🛠️ Changes
- [x] BaseEntity 세팅
- [x] 리뷰 도메인 엔티티 생성
- [x] 알림 도메인 엔티티 생성  

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?