### PR TITLE
[FEAT/#36] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,11 @@ dependencies {
     // Spatial 기능 추가 (Point 타입 사용을 위해)
     implementation 'org.hibernate.orm:hibernate-spatial'
 	runtimeOnly 'com.h2database:h2'
-	// 로그인 관련 기능
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// 보안
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// 카카오 로그인
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -22,6 +22,15 @@ public class UserRestController {
   private final UserQueryService userQueryService;
   private final UserCommandService userCommandService;
 
+  @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호를 입력받아 업데이트합니다.")
+  @PostMapping("/extra/info")
+  public ApiResponse<String> createExtraInfo(@RequestBody UserRequestDTO.ExtraInfoDTO request) {
+    // TODO: JWT 완성 후 SecurityContext에서 추출하도록 변경 필요
+    Long userId = 1L;
+    userCommandService.updateExtraInfo(userId, request);
+    return ApiResponse.of(GeneralSuccessCode.OK, "정보 저장이 완료되었습니다.");
+  }
+
   @Operation(summary = "내 정보 조회 API", description = "로그인된 사용자의 프로필 정보를 조회합니다.")
   @GetMapping("/me")
   public ApiResponse<UserResponseDTO.UserProfileDTO> getMemberProfile() {

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -10,6 +10,7 @@ import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +25,8 @@ public class UserRestController {
 
   @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호를 입력받아 업데이트합니다.")
   @PostMapping("/extra/info")
-  public ApiResponse<String> createExtraInfo(@RequestBody UserRequestDTO.ExtraInfoDTO request) {
+  public ApiResponse<String> createExtraInfo(
+      @Valid @RequestBody UserRequestDTO.ExtraInfoDTO request) {
     // TODO: JWT 완성 후 SecurityContext에서 추출하도록 변경 필요
     Long userId = 1L;
     userCommandService.updateExtraInfo(userId, request);

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/KakaoUserInfo.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/KakaoUserInfo.java
@@ -15,7 +15,11 @@ public class KakaoUserInfo implements OAuth2UserInfo {
     if (id instanceof Number) {
       return ((Number) id).longValue();
     }
-    return Long.parseLong(String.valueOf(id));
+    try {
+      return Long.parseLong(String.valueOf(id));
+    } catch (NumberFormatException ex) {
+      throw new IllegalStateException("Invalid Kakao id: " + id, ex);
+    }
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/KakaoUserInfo.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/KakaoUserInfo.java
@@ -20,7 +20,11 @@ public class KakaoUserInfo implements OAuth2UserInfo {
 
   @Override
   public String getEmail() {
-    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-    return (String) kakaoAccount.get("email");
+    Object kakaoAccountObj = attributes.get("kakao_account");
+    if (kakaoAccountObj instanceof Map) {
+      Map<String, Object> kakaoAccount = (Map<String, Object>) kakaoAccountObj;
+      return (String) kakaoAccount.get("email");
+    }
+    return null;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/KakaoUserInfo.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/KakaoUserInfo.java
@@ -1,0 +1,26 @@
+package com.example.picknwhip_be.domain.user.dto.auth;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo {
+  private Map<String, Object> attributes;
+
+  public KakaoUserInfo(Map<String, Object> attributes) {
+    this.attributes = attributes;
+  }
+
+  @Override
+  public Long getKakaoId() {
+    Object id = attributes.get("id");
+    if (id instanceof Number) {
+      return ((Number) id).longValue();
+    }
+    return Long.parseLong(String.valueOf(id));
+  }
+
+  @Override
+  public String getEmail() {
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+    return (String) kakaoAccount.get("email");
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/OAuth2UserInfo.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/auth/OAuth2UserInfo.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.user.dto.auth;
+
+public interface OAuth2UserInfo {
+  Long getKakaoId();
+
+  String getEmail();
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/req/UserRequestDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/req/UserRequestDTO.java
@@ -20,6 +20,14 @@ public class UserRequestDTO {
   @Getter
   @NoArgsConstructor
   @AllArgsConstructor
+  public static class ExtraInfoDTO {
+    private String name;
+    private String phone;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class WithdrawalDTO {
     private List<WithdrawalReason> reasons;
     private String feedback;

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
@@ -28,13 +28,13 @@ public class User extends BaseEntity {
   @Column(unique = true, nullable = false)
   private String email; // 카카오에서 가져옴
 
-  @Column(nullable = false)
+  @Column(nullable = true)
   private String name;
 
   @Column(unique = true, nullable = false)
   private String nickname;
 
-  @Column(nullable = false)
+  @Column(nullable = true)
   private String phone;
 
   @Column(columnDefinition = "TEXT")
@@ -48,22 +48,19 @@ public class User extends BaseEntity {
   private LocalDateTime deletedAt;
 
   // 카카오 최초 로그인 시 계정 생성
-  public static User createKakaoUser(
-      Long kakaoId,
-      String email,
-      String name,
-      String nickname,
-      String phone,
-      String profileImageUrl) {
+  public static User createKakaoUser(Long kakaoId, String email, String nickname) {
     return User.builder()
         .kakaoId(kakaoId)
         .email(email)
-        .name(name)
         .nickname(nickname)
-        .phone(phone)
-        .profileImageUrl(profileImageUrl)
         .status(UserStatus.ACTIVE)
         .build();
+  }
+
+  // 카카오 로그인 후 추가 정보 입력
+  public void updateExtraInfo(String name, String phone) {
+    this.name = name;
+    this.phone = phone;
   }
 
   // 마이페이지 수정

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,34 @@
+package com.example.picknwhip_be.domain.user.service;
+
+import com.example.picknwhip_be.domain.user.dto.auth.KakaoUserInfo;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  private final UserCommandService userCommandService;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+    KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+
+    // 이메일만으로 우선 가입
+    userCommandService.joinOrCreateUser(
+        kakaoUserInfo.getKakaoId(), kakaoUserInfo.getEmail(), null, null, null);
+
+    return new DefaultOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+        oAuth2User.getAttributes(),
+        "id");
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandService.java
@@ -7,6 +7,8 @@ public interface UserCommandService {
   User joinOrCreateUser(
       Long kakaoId, String email, String name, String phone, String profileImageUrl);
 
+  void updateExtraInfo(Long userId, UserRequestDTO.ExtraInfoDTO request);
+
   User updateProfile(Long userId, UserRequestDTO.UpdateProfileDTO request);
 
   void withdrawMember(Long userId, UserRequestDTO.WithdrawalDTO request);

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -50,7 +50,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     // 무한 루프를 방지하기 위해 최대 시도 횟수를 제한
     for (int attempt = 0; attempt < MAX_NICKNAME_GENERATION_ATTEMPTS; attempt++) {
-      int randomNumber = random.nextInt(100_000, 1_000_000); // 범위를 넓혀 중복 확률 감소
+      int randomNumber = random.nextInt(100, 1000);
       String nickname = adjectives[random.nextInt(adjectives.length)] + randomNumber;
 
       if (!userRepository.existsByNickname(nickname)) {

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -37,9 +37,7 @@ public class UserCommandServiceImpl implements UserCommandService {
             () -> {
               // 가입된 적이 없으면 랜덤 닉네임 생성 후 등록
               String randomNickname = generateRandomNickname();
-              User newUser =
-                  User.createKakaoUser(
-                      kakaoId, email, name, randomNickname, phone, profileImageUrl);
+              User newUser = User.createKakaoUser(kakaoId, email, randomNickname);
               return userRepository.save(newUser);
             });
   }
@@ -68,6 +66,16 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     throw new GeneralException(GeneralErrorCode.NICKNAME_ALREADY_EXISTS);
+  }
+
+  @Override
+  public void updateExtraInfo(Long userId, UserRequestDTO.ExtraInfoDTO request) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+    user.updateExtraInfo(request.getName(), request.getPhone());
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.example.picknwhip_be.global.apiPayload.config;
 
+import com.example.picknwhip_be.domain.user.service.CustomOAuth2UserService;
+import com.example.picknwhip_be.global.apiPayload.handler.OAuth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,7 +12,11 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final CustomOAuth2UserService customOAuth2UserService; // 주입
+  private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler; // 주입
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -25,7 +32,13 @@ public class SecurityConfig {
                     // 그 외의 모든 요청은 일단 허용 (나중에 로그인이 완성되면 인증 필요로 변경)
                     // TODO: 배포 전 반드시 authenticated()로 변경할 것
                     .anyRequest()
-                    .permitAll());
+                    .permitAll())
+        // OAuth2 로그인 설정
+        .oauth2Login(
+            oauth2 ->
+                oauth2
+                    .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                    .successHandler(oAuth2AuthenticationSuccessHandler));
 
     return http.build();
   }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,45 @@
+package com.example.picknwhip_be.global.apiPayload.handler;
+
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication; // 반드시 이 임포트여야 함!
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException {
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+    // Number 방식 추출
+    Object idAttr = oAuth2User.getAttributes().get("id");
+    Long kakaoId =
+        (idAttr instanceof Number)
+            ? ((Number) idAttr).longValue()
+            : Long.parseLong(String.valueOf(idAttr));
+
+    User user =
+        userRepository
+            .findByKakaoId(kakaoId)
+            .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다. kakaoId: " + kakaoId));
+
+    // 이름이나 전화번호가 없으면 무조건 추가 정보 입력 페이지로 리다이렉트
+    if (user.getName() == null || user.getPhone() == null) {
+      getRedirectStrategy().sendRedirect(request, response, "http://localhost:3000/signup/extra");
+    } else {
+      getRedirectStrategy().sendRedirect(request, response, "/");
+    }
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication; // 반드시 이 임포트여야 함!
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.example.picknwhip_be.global.apiPayload.handler;
 
+import com.example.picknwhip_be.domain.user.dto.auth.KakaoUserInfo;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,12 +24,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
       throws IOException {
     OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-    // Number 방식 추출
-    Object idAttr = oAuth2User.getAttributes().get("id");
-    Long kakaoId =
-        (idAttr instanceof Number)
-            ? ((Number) idAttr).longValue()
-            : Long.parseLong(String.valueOf(idAttr));
+    KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+    Long kakaoId = kakaoUserInfo.getKakaoId();
 
     User user =
         userRepository

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,23 @@
 spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "${BASE_URL:http://localhost:8080}/login/oauth2/code/kakao"
+            scope: account_email
+            client-name: Kakao
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
   config:
     import: optional:env[.env]
 


### PR DESCRIPTION
## 💡 Issue
- Close #36 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- Spring Security 와 OAuth2 Client를 활용하여 카카오 소셜 로그인 기능 구현
- 이름과 전화번호 정보는 카카오 인증 직후 별도 페이지에서 수집하는 프로세스 구축(프론트 주소 필요)
- 노션 env 파일 참고

## 🛠️ Changes
- [x] OAuth2 로그인 및 보안 설정 추가: SecurityConfig에 oauth2Login 설정을 추가하고, 커스텀 서비스와 핸들러를 연동
- [x] 카카오 유저 정보 파싱 로직: KakaoUserInfo에서 카카오 고유 ID를 가져올 때, Integer와 Long 타입 모두에 대응할 수 있도록 Number 클래스를 활용
- [x] 엔티티 및 가입 로직 수정: User 엔티티의 name과 phone 필드에 nullable = true 제약 조건 적용 및 UserCommandService에 카카오 유저 생성 로직 및 추가 정보 업데이트 메서드 구현
- [x] 조건부 리다이렉트 핸들러 구현: OAuth2AuthenticationSuccessHandler를 통해 로그인 성공 유저의 정보를 확인하여, 필수 정보(이름, 번호)가 없는 경우 추가 정보 입력 페이지(/api/users/extra/info)로 강제 리다이렉트되도록 설정
- [x] 추가 정보 저장 API 개발: UserRestController에 신규 가입자가 입력한 이름과 전화번호를 DB에 반영하는 API 엔드포인트를 추가

## 📸 Screenshots
카카오 로그인 순서는 아래와 같습니다.
<img width="1342" height="906" alt="스크린샷 2026-01-18 21 53 38" src="https://github.com/user-attachments/assets/a5116c0f-315e-486c-8bdb-f10870afe656" />
<img width="1342" height="906" alt="스크린샷 2026-01-18 21 54 01" src="https://github.com/user-attachments/assets/1da0d1eb-8995-438c-b46a-07ea4464710f" />
<img width="828" height="231" alt="스크린샷 2026-01-18 21 54 20" src="https://github.com/user-attachments/assets/dcedae28-4298-4f2b-94d1-dd9652e8ad4d" />

순서를 따른 후 로그를 보면 성공적으로 만들어진걸 볼 수 있습니다.
<img width="314" height="437" alt="스크린샷 2026-01-18 21 55 48" src="https://github.com/user-attachments/assets/598ac061-cd0a-4b56-be1f-52aa6760c8ec" />


## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?