### PR TITLE
[FEAT/#40] 1:1 문의 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// 카카오 로그인
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
@@ -1,0 +1,54 @@
+package com.example.picknwhip_be.domain.chat.controller;
+
+import com.example.picknwhip_be.domain.chat.converter.ChatConverter;
+import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+import com.example.picknwhip_be.domain.chat.service.ChatCommandService;
+import com.example.picknwhip_be.domain.chat.service.ChatQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+  private final SimpMessagingTemplate messagingTemplate;
+  private final ChatCommandService chatCommandService;
+  private final ChatQueryService chatQueryService;
+
+  @MessageMapping("/chats/{roomId}/messages")
+  public void sendMessage(@DestinationVariable Long roomId, ChatRequestDTO.SendMessageDTO dto) {
+    // TODO: SecurityContext 연동 (임시 1L)
+    Long senderId = 1L;
+
+    // 메시지 저장 및 권한 체크
+    ChatMessage savedMessage = chatCommandService.saveMessage(roomId, dto, senderId);
+    ChatResponseDTO.MessageInfo response = ChatConverter.toMessageInfo(savedMessage);
+
+    // 채팅방 참여자들에게 메시지 실시간 브로드캐스트
+    messagingTemplate.convertAndSend("/topic/chats/" + roomId, response);
+
+    // 실시간 안읽은 카운트 알림 처리
+    Long customerId = savedMessage.getChatRoom().getCustomer().getUserId();
+    Long shopId = savedMessage.getChatRoom().getShop().getId();
+    Long shopOwnerId = savedMessage.getChatRoom().getShop().getOwner().getUserId();
+
+    // 수신자 결정 및 카운트 조회
+    Long receiverId = senderId.equals(customerId) ? shopOwnerId : customerId;
+    Long unreadCount = chatQueryService.getUnreadCount(roomId, receiverId);
+
+    ChatResponseDTO.UnreadCountUpdateDTO unreadUpdate =
+        ChatConverter.toUnreadCountUpdateDTO(roomId, unreadCount);
+
+    if (senderId.equals(customerId)) {
+      // 발신자가 고객인 경우 -> 사장님에게 알림 전송
+      messagingTemplate.convertAndSend("/topic/shops/" + shopId, "새로운 문의 메시지가 도착했습니다.");
+    } else if (senderId.equals(shopOwnerId)) {
+      // 발신자가 사장님인 경우 -> 고객에게 알림 전송
+      messagingTemplate.convertAndSend("/topic/users/" + customerId, "사장님의 메시지가 도착했습니다.");
+    }
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
@@ -19,7 +19,7 @@ public class ChatController {
   private final ChatCommandService chatCommandService;
   private final ChatQueryService chatQueryService;
 
-  @MessageMapping("/chats/{roomId}/messages")
+  @MessageMapping("api/chats/{roomId}/messages")
   public void sendMessage(@DestinationVariable Long roomId, ChatRequestDTO.SendMessageDTO dto) {
     // TODO: SecurityContext 연동 (임시 1L)
     Long senderId = 1L;

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
@@ -43,6 +43,8 @@ public class ChatController {
     ChatResponseDTO.UnreadCountUpdateDTO unreadUpdate =
         ChatConverter.toUnreadCountUpdateDTO(roomId, unreadCount);
 
+    messagingTemplate.convertAndSend("/topic/users/" + receiverId + "/unread", unreadUpdate);
+
     if (senderId.equals(customerId)) {
       // 발신자가 고객인 경우 -> 사장님에게 알림 전송
       messagingTemplate.convertAndSend("/topic/shops/" + shopId, "새로운 문의 메시지가 도착했습니다.");

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -1,0 +1,55 @@
+package com.example.picknwhip_be.domain.chat.controller;
+
+import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import com.example.picknwhip_be.domain.chat.service.ChatCommandService;
+import com.example.picknwhip_be.domain.chat.service.ChatQueryService;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Chat", description = "1:1 문의 채팅 관련 API")
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+public class ChatRestController {
+  private final ChatCommandService chatCommandService;
+  private final ChatQueryService chatQueryService;
+
+  @Operation(summary = "채팅방 생성 또는 조회 API", description = "기존 채팅방이 있으면 조회하고, 없으면 새로 생성하여 정보를 반환합니다.")
+  @PostMapping
+  public ApiResponse<ChatResponseDTO.RoomInfo> createRoom(
+      @RequestBody ChatRequestDTO.CreateRoom dto) {
+    Long userId = 1L; // TODO: Security 연동
+    return ApiResponse.of(GeneralSuccessCode.OK, chatCommandService.saveOrCreateRoom(dto, userId));
+  }
+
+  @Operation(
+      summary = "채팅 메시지 내역 조회 API",
+      description = "특정 채팅방의 모든 메시지를 시간순으로 조회하며, 상대방이 보낸 메시지는 읽음 처리됩니다.")
+  @GetMapping("/{roomId}/messages")
+  public ApiResponse<List<ChatResponseDTO.MessageInfo>> getMessages(@PathVariable Long roomId) {
+    Long userId = 1L; // TODO: Security 연동
+    chatCommandService.updateMarkAsRead(roomId, userId);
+    return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.findMessages(roomId));
+  }
+
+  // TODO: S3 이미지 업로드 로직 구현 필요
+  // @Operation(summary = "채팅 이미지 업로드 API", description = "채팅 중 전송할 이미지를 업로드하고 S3 URL을 반환받습니다.")
+  // @PostMapping("/{roomId}/images")
+  // public ApiResponse<String> createChatImage(@PathVariable Long roomId, @RequestParam("file")
+  // MultipartFile file) {
+  //    return ApiResponse.of(GeneralSuccessCode.OK, "http://temp-s3-url.com/image.jpg");
+  //  }
+
+  @Operation(summary = "내 채팅방 목록 조회 API", description = "로그인한 사용자가 참여 중인 모든 채팅방 목록을 조회합니다.")
+  @GetMapping
+  public ApiResponse<ChatResponseDTO.ChatRoomListDTO> getChatRoomList() {
+    Long userId = 1L; // TODO: Security 연동
+    return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.getChatRoomList(userId));
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -8,7 +8,6 @@ import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,21 +28,20 @@ public class ChatRestController {
   }
 
   @Operation(
-          summary = "채팅 메시지 내역 조회 (페이징) API",
-          description = "커서 기반 페이징을 사용하여 메시지 내역을 조회합니다. 특정 채팅방의 메시지를 과거 순으로 불러오며, 상대방이 보낸 메시지는 읽음 처리됩니다."
-  )
+      summary = "채팅 메시지 내역 조회 (페이징) API",
+      description =
+          "커서 기반 페이징을 사용하여 메시지 내역을 조회합니다. 특정 채팅방의 메시지를 과거 순으로 불러오며, 상대방이 보낸 메시지는 읽음 처리됩니다.")
   @GetMapping("/{roomId}/messages")
   public ApiResponse<ChatResponseDTO.MessageListDTO> getMessages(
-          @PathVariable Long roomId,
-          @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 메시지 ID
-          @RequestParam(defaultValue = "10") Integer size // 한 번에 가져올 메시지 개수
-  ) {
+      @PathVariable Long roomId,
+      @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 메시지 ID
+      @RequestParam(defaultValue = "10") Integer size // 한 번에 가져올 메시지 개수
+      ) {
     Long userId = 1L; // TODO: Security 연동
     chatCommandService.updateMarkAsRead(roomId, userId);
-    return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.getMessages(roomId, cursor, size));
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, chatQueryService.getMessages(roomId, cursor, size));
   }
-
-
 
   // TODO: S3 이미지 업로드 로직 구현 필요
   // @Operation(summary = "채팅 이미지 업로드 API", description = "채팅 중 전송할 이미지를 업로드하고 S3 URL을 반환받습니다.")
@@ -59,5 +57,4 @@ public class ChatRestController {
     Long userId = 1L; // TODO: Security 연동
     return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.getChatRoomList(userId));
   }
-
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -29,14 +29,21 @@ public class ChatRestController {
   }
 
   @Operation(
-      summary = "채팅 메시지 내역 조회 API",
-      description = "특정 채팅방의 모든 메시지를 시간순으로 조회하며, 상대방이 보낸 메시지는 읽음 처리됩니다.")
+          summary = "채팅 메시지 내역 조회 (페이징) API",
+          description = "커서 기반 페이징을 사용하여 메시지 내역을 조회합니다. 특정 채팅방의 메시지를 과거 순으로 불러오며, 상대방이 보낸 메시지는 읽음 처리됩니다."
+  )
   @GetMapping("/{roomId}/messages")
-  public ApiResponse<List<ChatResponseDTO.MessageInfo>> getMessages(@PathVariable Long roomId) {
+  public ApiResponse<ChatResponseDTO.MessageListDTO> getMessages(
+          @PathVariable Long roomId,
+          @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 메시지 ID
+          @RequestParam(defaultValue = "10") Integer size // 한 번에 가져올 메시지 개수
+  ) {
     Long userId = 1L; // TODO: Security 연동
     chatCommandService.updateMarkAsRead(roomId, userId);
-    return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.findMessages(roomId));
+    return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.getMessages(roomId, cursor, size));
   }
+
+
 
   // TODO: S3 이미지 업로드 로직 구현 필요
   // @Operation(summary = "채팅 이미지 업로드 API", description = "채팅 중 전송할 이미지를 업로드하고 S3 URL을 반환받습니다.")
@@ -52,4 +59,5 @@ public class ChatRestController {
     Long userId = 1L; // TODO: Security 연동
     return ApiResponse.of(GeneralSuccessCode.OK, chatQueryService.getChatRoomList(userId));
   }
+
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
@@ -1,0 +1,66 @@
+package com.example.picknwhip_be.domain.chat.converter;
+
+import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.user.entity.User;
+import java.util.List;
+
+public class ChatConverter {
+  public static ChatResponseDTO.RoomInfo toRoomInfo(ChatRoom room) {
+    return ChatResponseDTO.RoomInfo.builder()
+        .roomId(room.getChatRoomId())
+        .shopName(room.getShop().getShopName())
+        .build();
+  }
+
+  public static ChatResponseDTO.MessageInfo toMessageInfo(ChatMessage message) {
+    return ChatResponseDTO.MessageInfo.builder()
+        .messageId(message.getChatId())
+        .senderId(message.getSender().getUserId())
+        .content(message.getMessageText())
+        .imageUrl(message.getMessageImageUrl())
+        .type(message.getMessageType())
+        .isRead(message.isRead())
+        .createdAt(message.getCreatedAt())
+        .build();
+  }
+
+  public static ChatMessage toChatMessage(
+      ChatRoom room, User sender, ChatRequestDTO.SendMessageDTO dto) {
+    return ChatMessage.builder()
+        .chatRoom(room)
+        .sender(sender)
+        .messageType(dto.getType())
+        .messageText(dto.getContent())
+        .messageImageUrl(dto.getImageUrl())
+        .build();
+  }
+
+  public static ChatResponseDTO.ChatRoomSummaryDTO toChatRoomSummaryDTO(
+      ChatRoom room, ChatMessage lastMessage, Long unreadCount) {
+
+    return ChatResponseDTO.ChatRoomSummaryDTO.builder()
+        .roomId(room.getChatRoomId())
+        .shopName(room.getShop().getShopName())
+        .shopImageUrl(room.getShop().getShopImageUrl())
+        .lastMessage(lastMessage != null ? lastMessage.getMessageText() : "메시지가 없습니다.")
+        .lastMessageTime(lastMessage != null ? lastMessage.getCreatedAt() : room.getCreatedAt())
+        .unreadCount(unreadCount)
+        .build();
+  }
+
+  public static ChatResponseDTO.ChatRoomListDTO toChatRoomListDTO(
+      List<ChatResponseDTO.ChatRoomSummaryDTO> summaryList) {
+    return ChatResponseDTO.ChatRoomListDTO.builder().chatRooms(summaryList).build();
+  }
+
+  public static ChatResponseDTO.UnreadCountUpdateDTO toUnreadCountUpdateDTO(
+      Long roomId, Long unreadCount) {
+    return ChatResponseDTO.UnreadCountUpdateDTO.builder()
+        .roomId(roomId)
+        .unreadCount(unreadCount)
+        .build();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/req/ChatRequestDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/req/ChatRequestDTO.java
@@ -1,0 +1,24 @@
+package com.example.picknwhip_be.domain.chat.dto.req;
+
+import com.example.picknwhip_be.domain.chat.entity.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatRequestDTO {
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class CreateRoom {
+    private Long shopId;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SendMessageDTO {
+    private MessageType type;
+    private String content;
+    private String imageUrl;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResponseDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResponseDTO.java
@@ -1,0 +1,64 @@
+package com.example.picknwhip_be.domain.chat.dto.res;
+
+import com.example.picknwhip_be.domain.chat.entity.MessageType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatResponseDTO {
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class RoomInfo {
+    private Long roomId;
+    private String shopName;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class MessageInfo {
+    private Long messageId;
+    private Long senderId;
+    private String content;
+    private String imageUrl;
+    private MessageType type;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ChatRoomSummaryDTO {
+    private Long roomId;
+    private String shopName;
+    private String shopImageUrl;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+    private Long unreadCount;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ChatRoomListDTO {
+    private List<ChatRoomSummaryDTO> chatRooms;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class UnreadCountUpdateDTO {
+    private Long roomId;
+    private Long unreadCount;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResponseDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResponseDTO.java
@@ -3,6 +3,8 @@ package com.example.picknwhip_be.domain.chat.dto.res;
 import com.example.picknwhip_be.domain.chat.entity.MessageType;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,5 +62,15 @@ public class ChatResponseDTO {
   public static class UnreadCountUpdateDTO {
     private Long roomId;
     private Long unreadCount;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class MessageListDTO {
+    private List<MessageInfo> messageList;
+    private Long nextCursor;
+    private boolean hasNext;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResponseDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResponseDTO.java
@@ -3,8 +3,6 @@ package com.example.picknwhip_be.domain.chat.dto.res;
 import com.example.picknwhip_be.domain.chat.entity.MessageType;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/picknwhip_be/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,43 @@
+package com.example.picknwhip_be.domain.chat.entity;
+
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "chat_messages")
+public class ChatMessage extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long chatId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "room_id")
+  private ChatRoom chatRoom;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_id")
+  private User sender;
+
+  @Enumerated(EnumType.STRING)
+  private MessageType messageType;
+
+  @Column(columnDefinition = "TEXT")
+  private String messageText;
+
+  private String messageImageUrl;
+
+  @Builder.Default private boolean isRead = false;
+
+  public void markAsRead() {
+    this.isRead = true;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,36 @@
+package com.example.picknwhip_be.domain.chat.entity;
+
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "chat_rooms")
+public class ChatRoom extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long chatRoomId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "customer_id")
+  private User customer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "shop_id")
+  private Shop shop;
+
+  private Long lastMessageId;
+
+  public void updateLastMessage(Long messageId) {
+    this.lastMessageId = messageId;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/entity/MessageType.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/entity/MessageType.java
@@ -1,0 +1,6 @@
+package com.example.picknwhip_be.domain.chat.entity;
+
+public enum MessageType {
+  TEXT,
+  IMAGE
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/exception/ChatException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/exception/ChatException.java
@@ -1,0 +1,15 @@
+package com.example.picknwhip_be.domain.chat.exception;
+
+import com.example.picknwhip_be.domain.chat.exception.code.ChatErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ChatException extends RuntimeException {
+
+  private final ChatErrorCode code;
+
+  public ChatException(ChatErrorCode code) {
+    super(code.getMessage());
+    this.code = code;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/exception/code/ChatErrorCode.java
@@ -8,13 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ChatErrorCode implements BaseErrorCode {
+  CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_1", "존재하지 않는 채팅방입니다."),
+  CHAT_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "CHAT403_1", "해당 채팅방의 참여자가 아닙니다."),
+  INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "CHAT400_1", "잘못된 메시지 형식입니다."),
+  MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_2", "메시지를 찾을 수 없습니다.");
 
-    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_1", "존재하지 않는 채팅방입니다."),
-    CHAT_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "CHAT403_1", "해당 채팅방의 참여자가 아닙니다."),
-    INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "CHAT400_1", "잘못된 메시지 형식입니다."),
-    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_2", "메시지를 찾을 수 없습니다.");
-
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/exception/code/ChatErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.picknwhip_be.domain.chat.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ChatErrorCode implements BaseErrorCode {
+
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_1", "존재하지 않는 채팅방입니다."),
+    CHAT_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "CHAT403_1", "해당 채팅방의 참여자가 아닙니다."),
+    INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "CHAT400_1", "잘못된 메시지 형식입니다."),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_2", "메시지를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
@@ -4,7 +4,6 @@ import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
 import com.example.picknwhip_be.domain.user.entity.User;
 import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -29,14 +28,15 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
       @Param("roomIds") List<Long> roomIds, @Param("user") User user);
 
   // 커서 페이징: 특정 ID(cursor)보다 작은 메시지들을 최신순으로 조회
-  @Query("SELECT m FROM ChatMessage m " +
-          "JOIN FETCH m.sender " +
-          "WHERE m.chatRoom.chatRoomId = :roomId " +
-          "AND (:cursor IS NULL OR m.chatId < :cursor) " + // 커서가 null이면 가장 최신부터
+  @Query(
+      "SELECT m FROM ChatMessage m "
+          + "JOIN FETCH m.sender "
+          + "WHERE m.chatRoom.chatRoomId = :roomId "
+          + "AND (:cursor IS NULL OR m.chatId < :cursor) "
+          + // 커서가 null이면 가장 최신부터
           "ORDER BY m.chatId DESC")
-  List<ChatMessage> findMessagesWithCursor(@Param("roomId") Long roomId,
-                                           @Param("cursor") Long cursor,
-                                           Pageable pageable);
+  List<ChatMessage> findMessagesWithCursor(
+      @Param("roomId") Long roomId, @Param("cursor") Long cursor, Pageable pageable);
 
   Long countByChatRoom_ChatRoomIdAndIsReadFalseAndSender_UserIdNot(Long chatRoomId, Long userId);
 

--- a/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
@@ -4,6 +4,8 @@ import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
 import com.example.picknwhip_be.domain.user.entity.User;
 import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -25,6 +27,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
           + "GROUP BY m.chatRoom.chatRoomId")
   List<Object[]> countUnreadMessagesByRoomIds(
       @Param("roomIds") List<Long> roomIds, @Param("user") User user);
+
+  // 커서 페이징: 특정 ID(cursor)보다 작은 메시지들을 최신순으로 조회
+  @Query("SELECT m FROM ChatMessage m " +
+          "JOIN FETCH m.sender " +
+          "WHERE m.chatRoom.chatRoomId = :roomId " +
+          "AND (:cursor IS NULL OR m.chatId < :cursor) " + // 커서가 null이면 가장 최신부터
+          "ORDER BY m.chatId DESC")
+  List<ChatMessage> findMessagesWithCursor(@Param("roomId") Long roomId,
+                                           @Param("cursor") Long cursor,
+                                           Pageable pageable);
 
   Long countByChatRoom_ChatRoomIdAndIsReadFalseAndSender_UserIdNot(Long chatRoomId, Long userId);
 

--- a/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,26 @@
+package com.example.picknwhip_be.domain.chat.repository;
+
+import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+  List<ChatMessage> findByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom);
+
+  // 마지막 메시지 1건 조회
+  Optional<ChatMessage> findTopByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom);
+
+  // 읽지 않은 메시지 개수 조회
+  Long countByChatRoomAndIsReadFalseAndSenderNot(ChatRoom chatRoom, User sender);
+
+  @Modifying
+  @Query(
+      "UPDATE ChatMessage m SET m.isRead = true WHERE m.chatRoom.chatRoomId = :roomId AND m.sender.userId != :userId")
+  void markAsReadByRoomId(@Param("roomId") Long roomId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatMessageRepository.java
@@ -4,7 +4,6 @@ import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
 import com.example.picknwhip_be.domain.user.entity.User;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,11 +12,21 @@ import org.springframework.data.repository.query.Param;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
   List<ChatMessage> findByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom);
 
-  // 마지막 메시지 1건 조회
-  Optional<ChatMessage> findTopByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom);
+  // 채팅방 ID 목록으로 각 방의 마지막 메시지들을 한꺼번에 조회
+  @Query(
+      "SELECT m FROM ChatMessage m WHERE m.chatId IN "
+          + "(SELECT MAX(m2.chatId) FROM ChatMessage m2 WHERE m2.chatRoom.chatRoomId IN :roomIds GROUP BY m2.chatRoom.chatRoomId)")
+  List<ChatMessage> findLastMessagesByRoomIds(@Param("roomIds") List<Long> roomIds);
 
-  // 읽지 않은 메시지 개수 조회
-  Long countByChatRoomAndIsReadFalseAndSenderNot(ChatRoom chatRoom, User sender);
+  // 채팅방 ID 목록으로 각 방의 안 읽은 메시지 개수를 그룹화하여 조회
+  @Query(
+      "SELECT m.chatRoom.chatRoomId, COUNT(m) FROM ChatMessage m "
+          + "WHERE m.chatRoom.chatRoomId IN :roomIds AND m.isRead = false AND m.sender != :user "
+          + "GROUP BY m.chatRoom.chatRoomId")
+  List<Object[]> countUnreadMessagesByRoomIds(
+      @Param("roomIds") List<Long> roomIds, @Param("user") User user);
+
+  Long countByChatRoom_ChatRoomIdAndIsReadFalseAndSender_UserIdNot(Long chatRoomId, Long userId);
 
   @Modifying
   @Query(

--- a/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,17 @@
+package com.example.picknwhip_be.domain.chat.repository;
+
+import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+  Optional<ChatRoom> findByCustomerAndShop(User customer, Shop shop);
+
+  @Query("SELECT r FROM ChatRoom r WHERE r.customer = :user OR r.shop.owner = :user")
+  List<ChatRoom> findAllByCustomerOrShopOwner(@Param("user") User user);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandService.java
@@ -1,0 +1,16 @@
+package com.example.picknwhip_be.domain.chat.service;
+
+import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+
+public interface ChatCommandService {
+  // 채팅방 생성, 기본 방 조회
+  ChatResponseDTO.RoomInfo saveOrCreateRoom(ChatRequestDTO.CreateRoom dto, Long customerId);
+
+  // 채팅 메시지 저장 및 권한 검증
+  ChatMessage saveMessage(Long roomId, ChatRequestDTO.SendMessageDTO dto, Long senderId);
+
+  // 채팅방 메시지 읽음 처리
+  void updateMarkAsRead(Long roomId, Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
@@ -61,7 +61,10 @@ public class ChatCommandServiceImpl implements ChatCommandService {
       throw new GeneralException(GeneralErrorCode.CHAT_NOT_PARTICIPANT);
     }
 
-    User sender = userRepository.findById(senderId).get();
+    User sender =
+        userRepository
+            .findById(senderId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
     ChatMessage message = ChatConverter.toChatMessage(room, sender, dto);
 
     ChatMessage saved = chatMessageRepository.save(message);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
@@ -1,0 +1,76 @@
+package com.example.picknwhip_be.domain.chat.service;
+
+import com.example.picknwhip_be.domain.chat.converter.ChatConverter;
+import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.chat.repository.ChatMessageRepository;
+import com.example.picknwhip_be.domain.chat.repository.ChatRoomRepository;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatCommandServiceImpl implements ChatCommandService {
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final UserRepository userRepository;
+  private final ShopRepository shopRepository;
+
+  @Override
+  public ChatResponseDTO.RoomInfo saveOrCreateRoom(ChatRequestDTO.CreateRoom dto, Long customerId) {
+    User customer =
+        userRepository
+            .findById(customerId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+    Shop shop =
+        shopRepository
+            .findById(dto.getShopId())
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
+
+    ChatRoom room =
+        chatRoomRepository
+            .findByCustomerAndShop(customer, shop)
+            .orElseGet(
+                () ->
+                    chatRoomRepository.save(
+                        ChatRoom.builder().customer(customer).shop(shop).build()));
+
+    return ChatConverter.toRoomInfo(room);
+  }
+
+  @Override
+  public ChatMessage saveMessage(Long roomId, ChatRequestDTO.SendMessageDTO dto, Long senderId) {
+    ChatRoom room =
+        chatRoomRepository
+            .findById(roomId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND));
+
+    // 권한 체크
+    if (!room.getCustomer().getUserId().equals(senderId)
+        && !room.getShop().getOwner().getUserId().equals(senderId)) {
+      throw new GeneralException(GeneralErrorCode.CHAT_NOT_PARTICIPANT);
+    }
+
+    User sender = userRepository.findById(senderId).get();
+    ChatMessage message = ChatConverter.toChatMessage(room, sender, dto);
+
+    ChatMessage saved = chatMessageRepository.save(message);
+    room.updateLastMessage(saved.getChatId());
+    return saved;
+  }
+
+  @Override
+  public void updateMarkAsRead(Long roomId, Long userId) {
+    chatMessageRepository.markAsReadByRoomId(roomId, userId);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
@@ -5,6 +5,8 @@ import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
 import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.chat.exception.ChatException;
+import com.example.picknwhip_be.domain.chat.exception.code.ChatErrorCode;
 import com.example.picknwhip_be.domain.chat.repository.ChatMessageRepository;
 import com.example.picknwhip_be.domain.chat.repository.ChatRoomRepository;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
@@ -53,12 +55,12 @@ public class ChatCommandServiceImpl implements ChatCommandService {
     ChatRoom room =
         chatRoomRepository
             .findById(roomId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND));
+            .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
     // 권한 체크
     if (!room.getCustomer().getUserId().equals(senderId)
         && !room.getShop().getOwner().getUserId().equals(senderId)) {
-      throw new GeneralException(GeneralErrorCode.CHAT_NOT_PARTICIPANT);
+      throw new ChatException(ChatErrorCode.CHAT_NOT_PARTICIPANT);
     }
 
     User sender =

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryService.java
@@ -1,7 +1,6 @@
 package com.example.picknwhip_be.domain.chat.service;
 
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
-import java.util.List;
 
 public interface ChatQueryService {
   // 채팅방의 모든 메시지 내역 조회

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryService.java
@@ -1,0 +1,15 @@
+package com.example.picknwhip_be.domain.chat.service;
+
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import java.util.List;
+
+public interface ChatQueryService {
+  // 채팅방의 모든 메시지 내역 조회
+  List<ChatResponseDTO.MessageInfo> findMessages(Long roomId);
+
+  // 채팅방 목록 조회
+  ChatResponseDTO.ChatRoomListDTO getChatRoomList(Long userId);
+
+  // 안읽은 메시지 실시간 업데이트
+  Long getUnreadCount(Long roomId, Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryService.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface ChatQueryService {
   // 채팅방의 모든 메시지 내역 조회
-  List<ChatResponseDTO.MessageInfo> findMessages(Long roomId);
+  ChatResponseDTO.MessageListDTO getMessages(Long roomId, Long cursor, Integer size);
 
   // 채팅방 목록 조회
   ChatResponseDTO.ChatRoomListDTO getChatRoomList(Long userId);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
@@ -10,8 +10,11 @@ import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +33,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     ChatRoom room =
         chatRoomRepository
             .findById(roomId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND));
 
     return chatMessageRepository.findByChatRoomOrderByCreatedAtAsc(room).stream()
         .map(ChatConverter::toMessageInfo)
@@ -44,29 +47,37 @@ public class ChatQueryServiceImpl implements ChatQueryService {
             .findById(userId)
             .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
-    // 유저가 참여 중인 채팅방 조회
+    // 유저가 참여 중인 채팅방 목록 조회
     List<ChatRoom> rooms = chatRoomRepository.findAllByCustomerOrShopOwner(user);
+    if (rooms.isEmpty()) {
+      return ChatConverter.toChatRoomListDTO(Collections.emptyList());
+    }
 
-    // 각 방별로 요약 정보 생성
+    // 채팅방 ID 리스트 추출
+    List<Long> roomIds = rooms.stream().map(ChatRoom::getChatRoomId).toList();
+
+    // 마지막 메시지들을 한꺼번에 조회하여 Map<RoomID, ChatMessage>으로 변환
+    Map<Long, ChatMessage> lastMessageMap =
+        chatMessageRepository.findLastMessagesByRoomIds(roomIds).stream()
+            .collect(Collectors.toMap(m -> m.getChatRoom().getChatRoomId(), m -> m));
+
+    // 안 읽은 개수들을 한꺼번에 조회하여 Map<RoomID, Long>으로 변환
+    Map<Long, Long> unreadCountMap =
+        chatMessageRepository.countUnreadMessagesByRoomIds(roomIds, user).stream()
+            .collect(Collectors.toMap(obj -> (Long) obj[0], obj -> (Long) obj[1]));
+
+    // 메모리에서 데이터 조합하여 DTO 생성
     List<ChatResponseDTO.ChatRoomSummaryDTO> summaryList =
         rooms.stream()
             .map(
                 room -> {
-                  // 마지막 메시지 조회
-                  ChatMessage lastMessage =
-                      chatMessageRepository
-                          .findTopByChatRoomOrderByCreatedAtDesc(room)
-                          .orElse(null);
-
-                  // 안읽은 메시지 카운트 (본인이 보낸 건 제외)
-                  Long unreadCount =
-                      chatMessageRepository.countByChatRoomAndIsReadFalseAndSenderNot(room, user);
-
+                  ChatMessage lastMessage = lastMessageMap.get(room.getChatRoomId());
+                  Long unreadCount = unreadCountMap.getOrDefault(room.getChatRoomId(), 0L);
                   return ChatConverter.toChatRoomSummaryDTO(room, lastMessage, unreadCount);
                 })
             .sorted(
                 Comparator.comparing(ChatResponseDTO.ChatRoomSummaryDTO::getLastMessageTime)
-                    .reversed()) // 최신순 정렬
+                    .reversed())
             .toList();
 
     return ChatConverter.toChatRoomListDTO(summaryList);
@@ -74,15 +85,13 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
   @Override
   public Long getUnreadCount(Long roomId, Long userId) {
-    ChatRoom room =
-        chatRoomRepository
-            .findById(roomId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND));
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+    // 채팅방 존재 여부 체크
+    if (!chatRoomRepository.existsById(roomId)) {
+      throw new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND);
+    }
 
-    return chatMessageRepository.countByChatRoomAndIsReadFalseAndSenderNot(room, user);
+    // User ID로 카운트 쿼리 실행
+    return chatMessageRepository.countByChatRoom_ChatRoomIdAndIsReadFalseAndSender_UserIdNot(
+        roomId, userId);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.picknwhip_be.domain.chat.converter.ChatConverter;
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
 import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.chat.exception.ChatException;
+import com.example.picknwhip_be.domain.chat.exception.code.ChatErrorCode;
 import com.example.picknwhip_be.domain.chat.repository.ChatMessageRepository;
 import com.example.picknwhip_be.domain.chat.repository.ChatRoomRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,15 +32,28 @@ public class ChatQueryServiceImpl implements ChatQueryService {
   private final ChatMessageRepository chatMessageRepository;
 
   @Override
-  public List<ChatResponseDTO.MessageInfo> findMessages(Long roomId) {
-    ChatRoom room =
-        chatRoomRepository
-            .findById(roomId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND));
+  public ChatResponseDTO.MessageListDTO getMessages(Long roomId, Long cursor, Integer size) {
+    // 요청한 size보다 1개 더 조회하여 다음 페이지 여부 확인
+    PageRequest pageRequest = PageRequest.of(0, size + 1);
+    List<ChatMessage> messages = chatMessageRepository.findMessagesWithCursor(roomId, cursor, pageRequest);
 
-    return chatMessageRepository.findByChatRoomOrderByCreatedAtAsc(room).stream()
-        .map(ChatConverter::toMessageInfo)
-        .toList();
+    boolean hasNext = messages.size() > size;
+    if (hasNext) {
+      messages = messages.subList(0, size); // 실제 필요한 개수만큼 자름
+    }
+
+    List<ChatResponseDTO.MessageInfo> messageInfos = messages.stream()
+            .map(ChatConverter::toMessageInfo)
+            .toList();
+
+    // 다음 커서는 현재 리스트의 가장 마지막 메시지 ID
+    Long nextCursor = messages.isEmpty() ? null : messages.get(messages.size() - 1).getChatId();
+
+    return ChatResponseDTO.MessageListDTO.builder()
+            .messageList(messageInfos)
+            .nextCursor(nextCursor)
+            .hasNext(hasNext)
+            .build();
   }
 
   @Override
@@ -87,11 +103,12 @@ public class ChatQueryServiceImpl implements ChatQueryService {
   public Long getUnreadCount(Long roomId, Long userId) {
     // 채팅방 존재 여부 체크
     if (!chatRoomRepository.existsById(roomId)) {
-      throw new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND);
+      throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
     }
 
     // User ID로 카운트 쿼리 실행
     return chatMessageRepository.countByChatRoom_ChatRoomIdAndIsReadFalseAndSender_UserIdNot(
         roomId, userId);
   }
+
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
@@ -35,25 +35,25 @@ public class ChatQueryServiceImpl implements ChatQueryService {
   public ChatResponseDTO.MessageListDTO getMessages(Long roomId, Long cursor, Integer size) {
     // 요청한 size보다 1개 더 조회하여 다음 페이지 여부 확인
     PageRequest pageRequest = PageRequest.of(0, size + 1);
-    List<ChatMessage> messages = chatMessageRepository.findMessagesWithCursor(roomId, cursor, pageRequest);
+    List<ChatMessage> messages =
+        chatMessageRepository.findMessagesWithCursor(roomId, cursor, pageRequest);
 
     boolean hasNext = messages.size() > size;
     if (hasNext) {
       messages = messages.subList(0, size); // 실제 필요한 개수만큼 자름
     }
 
-    List<ChatResponseDTO.MessageInfo> messageInfos = messages.stream()
-            .map(ChatConverter::toMessageInfo)
-            .toList();
+    List<ChatResponseDTO.MessageInfo> messageInfos =
+        messages.stream().map(ChatConverter::toMessageInfo).toList();
 
     // 다음 커서는 현재 리스트의 가장 마지막 메시지 ID
     Long nextCursor = messages.isEmpty() ? null : messages.get(messages.size() - 1).getChatId();
 
     return ChatResponseDTO.MessageListDTO.builder()
-            .messageList(messageInfos)
-            .nextCursor(nextCursor)
-            .hasNext(hasNext)
-            .build();
+        .messageList(messageInfos)
+        .nextCursor(nextCursor)
+        .hasNext(hasNext)
+        .build();
   }
 
   @Override
@@ -110,5 +110,4 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     return chatMessageRepository.countByChatRoom_ChatRoomIdAndIsReadFalseAndSender_UserIdNot(
         roomId, userId);
   }
-
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatQueryServiceImpl.java
@@ -1,0 +1,88 @@
+package com.example.picknwhip_be.domain.chat.service;
+
+import com.example.picknwhip_be.domain.chat.converter.ChatConverter;
+import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
+import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.chat.repository.ChatMessageRepository;
+import com.example.picknwhip_be.domain.chat.repository.ChatRoomRepository;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatQueryServiceImpl implements ChatQueryService {
+
+  private final UserRepository userRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+
+  @Override
+  public List<ChatResponseDTO.MessageInfo> findMessages(Long roomId) {
+    ChatRoom room =
+        chatRoomRepository
+            .findById(roomId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
+
+    return chatMessageRepository.findByChatRoomOrderByCreatedAtAsc(room).stream()
+        .map(ChatConverter::toMessageInfo)
+        .toList();
+  }
+
+  @Override
+  public ChatResponseDTO.ChatRoomListDTO getChatRoomList(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+    // 유저가 참여 중인 채팅방 조회
+    List<ChatRoom> rooms = chatRoomRepository.findAllByCustomerOrShopOwner(user);
+
+    // 각 방별로 요약 정보 생성
+    List<ChatResponseDTO.ChatRoomSummaryDTO> summaryList =
+        rooms.stream()
+            .map(
+                room -> {
+                  // 마지막 메시지 조회
+                  ChatMessage lastMessage =
+                      chatMessageRepository
+                          .findTopByChatRoomOrderByCreatedAtDesc(room)
+                          .orElse(null);
+
+                  // 안읽은 메시지 카운트 (본인이 보낸 건 제외)
+                  Long unreadCount =
+                      chatMessageRepository.countByChatRoomAndIsReadFalseAndSenderNot(room, user);
+
+                  return ChatConverter.toChatRoomSummaryDTO(room, lastMessage, unreadCount);
+                })
+            .sorted(
+                Comparator.comparing(ChatResponseDTO.ChatRoomSummaryDTO::getLastMessageTime)
+                    .reversed()) // 최신순 정렬
+            .toList();
+
+    return ChatConverter.toChatRoomListDTO(summaryList);
+  }
+
+  @Override
+  public Long getUnreadCount(Long roomId, Long userId) {
+    ChatRoom room =
+        chatRoomRepository
+            .findById(roomId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.CHAT_ROOM_NOT_FOUND));
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+    return chatMessageRepository.countByChatRoomAndIsReadFalseAndSenderNot(room, user);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Report", description = "신고 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reports")
+@RequestMapping("/api/reports")
 public class ReportRestController {
 
   private final ReportCommandService reportCommandService;

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/shops")
+@RequestMapping("/api/shops")
 @RequiredArgsConstructor
 @Tag(name = "Shop API", description = "가게 관련 API")
 public class ShopController {

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/api/users")
 public class UserRestController {
 
   private final UserQueryService userQueryService;

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/code/GeneralErrorCode.java
@@ -21,8 +21,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
   // shop
   INVALID_RADIUS(HttpStatus.BAD_REQUEST, "SHOP400_1", "반경(radius)은 0보다 크고 3000m 이하여야 합니다."),
   INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "SHOP400_2", "좌표(lat/lon) 값이 올바르지 않습니다."),
-  SHOP_NEARBY_QUERY_FAILED(
-      HttpStatus.INTERNAL_SERVER_ERROR, "SHOP500_3", "주변 가게 조회 중 서버 오류가 발생했습니다."),
+  SHOP_NEARBY_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SHOP500_3", "주변 가게 조회 중 서버 오류가 발생했습니다."),
   DUPLICATE_REPORT(HttpStatus.BAD_REQUEST, "REPORT400_1", "이미 해당 대상을 신고하셨습니다."),
   INVALID_REPORT_TARGET(HttpStatus.BAD_REQUEST, "REPORT400_2", "본인의 게시글이나 자신은 신고할 수 없습니다."),
   TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT404_1", "신고하려는 대상을 찾을 수 없습니다."),

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/code/GeneralErrorCode.java
@@ -15,6 +15,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "사용자를 찾을 수 없습니다."),
   NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER400_1", "이미 존재하는 닉네임입니다."),
   ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "USER409_1", "이미 탈퇴한 사용자입니다."),
+  CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404_1", "존재하지 않는 채팅방입니다."),
+  CHAT_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "CHAT403_1", "해당 채팅방의 참여자가 아닙니다."),
+  INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "CHAT400_1", "잘못된 메시지 형식입니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/code/GeneralErrorCode.java
@@ -21,7 +21,8 @@ public enum GeneralErrorCode implements BaseErrorCode {
   // shop
   INVALID_RADIUS(HttpStatus.BAD_REQUEST, "SHOP400_1", "반경(radius)은 0보다 크고 3000m 이하여야 합니다."),
   INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "SHOP400_2", "좌표(lat/lon) 값이 올바르지 않습니다."),
-  SHOP_NEARBY_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SHOP500_3", "주변 가게 조회 중 서버 오류가 발생했습니다."),
+  SHOP_NEARBY_QUERY_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "SHOP500_3", "주변 가게 조회 중 서버 오류가 발생했습니다."),
   DUPLICATE_REPORT(HttpStatus.BAD_REQUEST, "REPORT400_1", "이미 해당 대상을 신고하셨습니다."),
   INVALID_REPORT_TARGET(HttpStatus.BAD_REQUEST, "REPORT400_2", "본인의 게시글이나 자신은 신고할 수 없습니다."),
   TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT404_1", "신고하려는 대상을 찾을 수 없습니다."),

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
@@ -10,6 +10,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // TODO: 프론트엔드 애플리케이션 실제 도메인만 허용하도록 설정하기
     registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
   }
 

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.example.picknwhip_be.global.apiPayload.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    // 메시지 구독 요청
+    registry.enableSimpleBroker("/topic");
+    // 메시지 발행 요청
+    registry.setApplicationDestinationPrefixes("/app");
+  }
+}


### PR DESCRIPTION
## 💡 Issue
- Close #40 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 고객과 케이크샵 사장님 간의 1:1 실시간 채팅 기능 구현
- 실시간 안읽은 메시지 카운트 및 양방향 알림 기능 추가

## 🛠️ Changes
- [x] WebSocket/STOMP 환경 구축: /ws 엔드포인트를 설정하고 메시지 브로커(/topic, /app)를 통한 Pub/Sub 구조 설계
- [x] 채팅 도메인 설계
- [x] 양방향 실시간 알림: @MessageMapping 내에서 발신자(고객/사장님)를 판별하여 상대방에게 실시간 알림 및 안읽은 카운트를 전송하는 로직 구현
- [x] 읽음 처리 로직: 채팅 내역 조회 시 is_read 필드를 업데이트하고, 채팅방 목록에서 안읽은 메시지 개수를 실시간으로 계산하여 반환

## 📸 Screenshots
채팅방 생성 성공했습니다
<img width="1056" height="534" alt="스크린샷 2026-01-19 01 58 56" src="https://github.com/user-attachments/assets/6ec7024b-704f-4cb9-a14e-6a377714b4d2" />

STOMP 실시간 통신 테스트 성공
고객이 생성된 채팅방에 입장한 후 케이크숍에 문의를 남깁니다.
<img width="1056" height="687" alt="스크린샷 2026-01-19 02 06 43" src="https://github.com/user-attachments/assets/cf7152c9-cffd-4ac9-b474-62ec38abb76e" />

그럼 아래와 같이 사장님한테 알림이 뜹니다!
<img width="1056" height="687" alt="스크린샷 2026-01-19 02 06 51" src="https://github.com/user-attachments/assets/c713c518-8831-4aa0-8841-78775a88a873" />

채팅 메시지도 DB에 저장이 잘 되었습니다
<img width="1860" height="227" alt="스크린샷 2026-01-19 02 07 12" src="https://github.com/user-attachments/assets/5ff21fc3-db4a-45b6-83d7-af3a230c2c22" />

채팅 메시지 조회도 잘 되는 것을 볼 수 있습니다
<img width="1036" height="560" alt="스크린샷 2026-01-19 02 07 56" src="https://github.com/user-attachments/assets/9738811b-9e1e-49fd-9b7a-b924ece5a78d" />


## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?