### PR TITLE
[FEAT/#43] 가게 마이픽 등록/취소 API

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
@@ -1,0 +1,48 @@
+package com.example.picknwhip_be.domain.favorite.controller;
+
+import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
+import com.example.picknwhip_be.domain.favorite.exception.code.FavoriteShopSuccessCode;
+import com.example.picknwhip_be.domain.favorite.service.FavoriteShopService;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/shops")
+@RequiredArgsConstructor
+@Tag(name = "Favorite Shop", description = "마이픽(가게 찜) 관련 API")
+public class FavoriteShopController {
+
+    private final FavoriteShopService favoriteShopService;
+
+    // TODO: 실제 구현 시 userId는 토큰(Security)에서 추출해야 합니다.
+    // 테스트 편의를 위해 일단 @RequestParam으로 받거나, 하드코딩된 값(1L)을 사용한다고 가정합니다.
+
+    @Operation(summary = "마이픽 가게 등록", description = "특정 가게를 마이픽(즐겨찾기)에 추가합니다.")
+    @PostMapping("/{shopId}/favorite")
+    public ApiResponse<FavoriteShopResponse> addFavoriteShop(
+            @PathVariable Long shopId,
+            @RequestParam Long userId
+    ) {
+        FavoriteShopResponse result =
+                favoriteShopService.addFavoriteShop(userId, shopId);
+
+        return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_CREATED, result);
+    }
+
+    @Operation(summary = "마이픽 가게 취소", description = "마이픽에 등록된 가게를 삭제합니다.")
+    @DeleteMapping("/{shopId}/favorite")
+    public ApiResponse<FavoriteShopResponse> removeFavoriteShop(
+            @PathVariable Long shopId,
+            @RequestParam Long userId
+    ) {
+        FavoriteShopResponse result =
+                favoriteShopService.removeFavoriteShop(userId, shopId);
+
+        return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_DELETED, result);
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
@@ -15,32 +15,26 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Favorite Shop", description = "마이픽(가게 찜) 관련 API")
 public class FavoriteShopController {
 
-    private final FavoriteShopService favoriteShopService;
+  private final FavoriteShopService favoriteShopService;
 
-    // TODO: 실제 구현 시 userId는 토큰(Security)에서 추출해야 합니다.
-    // 테스트 편의를 위해 일단 @RequestParam으로 받거나, 하드코딩된 값(1L)을 사용한다고 가정합니다.
+  // TODO: 실제 구현 시 userId는 토큰(Security)에서 추출해야 합니다.
+  // 테스트 편의를 위해 일단 @RequestParam으로 받거나, 하드코딩된 값(1L)을 사용한다고 가정합니다.
 
-    @Operation(summary = "마이픽 가게 등록", description = "특정 가게를 마이픽(즐겨찾기)에 추가합니다.")
-    @PostMapping("/{shopId}/favorite")
-    public ApiResponse<FavoriteShopResponse> addFavoriteShop(
-            @PathVariable Long shopId,
-            @RequestParam Long userId
-    ) {
-        FavoriteShopResponse result =
-                favoriteShopService.addFavoriteShop(userId, shopId);
+  @Operation(summary = "마이픽 가게 등록", description = "특정 가게를 마이픽(즐겨찾기)에 추가합니다.")
+  @PostMapping("/{shopId}/favorite")
+  public ApiResponse<FavoriteShopResponse> addFavoriteShop(
+      @PathVariable Long shopId, @RequestParam Long userId) {
+    FavoriteShopResponse result = favoriteShopService.addFavoriteShop(userId, shopId);
 
-        return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_CREATED, result);
-    }
+    return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_CREATED, result);
+  }
 
-    @Operation(summary = "마이픽 가게 취소", description = "마이픽에 등록된 가게를 삭제합니다.")
-    @DeleteMapping("/{shopId}/favorite")
-    public ApiResponse<FavoriteShopResponse> removeFavoriteShop(
-            @PathVariable Long shopId,
-            @RequestParam Long userId
-    ) {
-        FavoriteShopResponse result =
-                favoriteShopService.removeFavoriteShop(userId, shopId);
+  @Operation(summary = "마이픽 가게 취소", description = "마이픽에 등록된 가게를 삭제합니다.")
+  @DeleteMapping("/{shopId}/favorite")
+  public ApiResponse<FavoriteShopResponse> removeFavoriteShop(
+      @PathVariable Long shopId, @RequestParam Long userId) {
+    FavoriteShopResponse result = favoriteShopService.removeFavoriteShop(userId, shopId);
 
-        return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_DELETED, result);
-    }
+    return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_DELETED, result);
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
@@ -4,15 +4,13 @@ import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
 import com.example.picknwhip_be.domain.favorite.exception.code.FavoriteShopSuccessCode;
 import com.example.picknwhip_be.domain.favorite.service.FavoriteShopService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
-import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/shops")
+@RequestMapping("/api/shops")
 @RequiredArgsConstructor
 @Tag(name = "Favorite Shop", description = "마이픽(가게 찜) 관련 API")
 public class FavoriteShopController {

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/converter/FavoriteShopConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/converter/FavoriteShopConverter.java
@@ -1,11 +1,12 @@
 package com.example.picknwhip_be.domain.favorite.converter;
+
 import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
 
 public class FavoriteShopConverter {
 
-    private FavoriteShopConverter() {}
+  private FavoriteShopConverter() {}
 
-    public static FavoriteShopResponse toResponse(Long shopId, boolean isFavorited) {
-        return new FavoriteShopResponse(shopId, isFavorited);
-    }
+  public static FavoriteShopResponse toResponse(Long shopId, boolean isFavorited) {
+    return new FavoriteShopResponse(shopId, isFavorited);
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/converter/FavoriteShopConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/converter/FavoriteShopConverter.java
@@ -1,0 +1,11 @@
+package com.example.picknwhip_be.domain.favorite.converter;
+import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
+
+public class FavoriteShopConverter {
+
+    private FavoriteShopConverter() {}
+
+    public static FavoriteShopResponse toResponse(Long shopId, boolean isFavorited) {
+        return new FavoriteShopResponse(shopId, isFavorited);
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/dto/res/FavoriteShopResponse.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/dto/res/FavoriteShopResponse.java
@@ -4,6 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "가게 찜 등록/취소 응답")
 public record FavoriteShopResponse(
-        @Schema(description = "가게 ID", example = "12") Long shopId,
-        @Schema(description = "현재 찜 상태", example = "true") boolean isFavorited
-) {}
+    @Schema(description = "가게 ID", example = "12") Long shopId,
+    @Schema(description = "현재 찜 상태", example = "true") boolean isFavorited) {}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/dto/res/FavoriteShopResponse.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/dto/res/FavoriteShopResponse.java
@@ -1,0 +1,9 @@
+package com.example.picknwhip_be.domain.favorite.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가게 찜 등록/취소 응답")
+public record FavoriteShopResponse(
+        @Schema(description = "가게 ID", example = "12") Long shopId,
+        @Schema(description = "현재 찜 상태", example = "true") boolean isFavorited
+) {}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/entity/FavoriteShop.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/entity/FavoriteShop.java
@@ -4,24 +4,43 @@ import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "favorite_shops")
+@Table(name = "favorite_shops", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_favorite_shop_user", columnNames = {"user_id", "shop_id"})
+}) // 한 유저가 같은 가게를 중복 찜하지 못하도록 DB 레벨 제약조건 명시
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class FavoriteShop {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "shop_id")
-  private Shop shop;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private Shop shop;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // 생성자 편의 메서드
+    public static FavoriteShop create(User user, Shop shop) {
+        return FavoriteShop.builder()
+                .user(user)
+                .shop(shop)
+                .build();
+    }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/entity/FavoriteShop.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/entity/FavoriteShop.java
@@ -3,16 +3,19 @@ package com.example.picknwhip_be.domain.favorite.entity;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.user.entity.User;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
 @Entity
-@Table(name = "favorite_shops", uniqueConstraints = {
-        @UniqueConstraint(name = "uk_favorite_shop_user", columnNames = {"user_id", "shop_id"})
-}) // 한 유저가 같은 가게를 중복 찜하지 못하도록 DB 레벨 제약조건 명시
+@Table(
+    name = "favorite_shops",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_favorite_shop_user",
+          columnNames = {"user_id", "shop_id"})
+    }) // 한 유저가 같은 가게를 중복 찜하지 못하도록 DB 레벨 제약조건 명시
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -20,27 +23,24 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class FavoriteShop {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "shop_id", nullable = false)
-    private Shop shop;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "shop_id", nullable = false)
+  private Shop shop;
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
 
-    // 생성자 편의 메서드
-    public static FavoriteShop create(User user, Shop shop) {
-        return FavoriteShop.builder()
-                .user(user)
-                .shop(shop)
-                .build();
-    }
+  // 생성자 편의 메서드
+  public static FavoriteShop create(User user, Shop shop) {
+    return FavoriteShop.builder().user(user).shop(shop).build();
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/entity/FavoriteShop.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/entity/FavoriteShop.java
@@ -1,4 +1,4 @@
-package com.example.picknwhip_be.domain.shop.entity.mapping;
+package com.example.picknwhip_be.domain.favorite.entity;
 
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.user.entity.User;

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/FavoriteShopException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/FavoriteShopException.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.favorite.exception;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+
+public class FavoriteShopException extends GeneralException {
+    public FavoriteShopException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/FavoriteShopException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/FavoriteShopException.java
@@ -4,7 +4,7 @@ import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 
 public class FavoriteShopException extends GeneralException {
-    public FavoriteShopException(BaseErrorCode code) {
-        super(code);
-    }
+  public FavoriteShopException(BaseErrorCode code) {
+    super(code);
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopErrorCode.java
@@ -10,8 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum FavoriteShopErrorCode implements BaseErrorCode {
   FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "FAVORITE409_1", "이미 마이픽에 등록된 가게입니다."),
   FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "FAVORITE404_1", "마이픽에 등록되지 않은 가게입니다."),
-  SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404_1", "존재하지 않는 가게입니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "존재하지 않는 사용자입니다.");
+  SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404_1", "존재하지 않는 가게입니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.picknwhip_be.domain.favorite.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FavoriteShopErrorCode implements BaseErrorCode {
+    FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "FAVORITE409_1", "이미 마이픽에 등록된 가게입니다."),
+    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "FAVORITE404_1", "마이픽에 등록되지 않은 가게입니다."),
+    SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404_1", "존재하지 않는 가게입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "존재하지 않는 사용자입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopErrorCode.java
@@ -8,12 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum FavoriteShopErrorCode implements BaseErrorCode {
-    FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "FAVORITE409_1", "이미 마이픽에 등록된 가게입니다."),
-    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "FAVORITE404_1", "마이픽에 등록되지 않은 가게입니다."),
-    SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404_1", "존재하지 않는 가게입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "존재하지 않는 사용자입니다.");
+  FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "FAVORITE409_1", "이미 마이픽에 등록된 가게입니다."),
+  FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "FAVORITE404_1", "마이픽에 등록되지 않은 가게입니다."),
+  SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404_1", "존재하지 않는 가게입니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "존재하지 않는 사용자입니다.");
 
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopSuccessCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopSuccessCode.java
@@ -1,0 +1,18 @@
+package com.example.picknwhip_be.domain.favorite.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FavoriteShopSuccessCode implements BaseSuccessCode {
+    FAVORITE_CREATED(HttpStatus.OK, "FAVORITE200_1", "마이픽에 등록되었습니다."),
+    FAVORITE_DELETED(HttpStatus.OK, "FAVORITE200_2", "마이픽 등록이 취소되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}
+

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopSuccessCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/exception/code/FavoriteShopSuccessCode.java
@@ -8,11 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum FavoriteShopSuccessCode implements BaseSuccessCode {
-    FAVORITE_CREATED(HttpStatus.OK, "FAVORITE200_1", "마이픽에 등록되었습니다."),
-    FAVORITE_DELETED(HttpStatus.OK, "FAVORITE200_2", "마이픽 등록이 취소되었습니다.");
+  FAVORITE_CREATED(HttpStatus.OK, "FAVORITE200_1", "마이픽에 등록되었습니다."),
+  FAVORITE_DELETED(HttpStatus.OK, "FAVORITE200_2", "마이픽 등록이 취소되었습니다.");
 
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
 }
-

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
@@ -1,0 +1,17 @@
+package com.example.picknwhip_be.domain.favorite.repository;
+
+import com.example.picknwhip_be.domain.favorite.entity.FavoriteShop;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FavoriteShopRepository extends JpaRepository<FavoriteShop, Long> {
+
+    // 특정 유저가 특정 가게를 찜했는지 확인
+    boolean existsByUserAndShop(User user, Shop shop);
+
+    // 찜 삭제를 위해 조회
+    Optional<FavoriteShop> findByUserAndShop(User user, Shop shop);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
@@ -3,15 +3,14 @@ package com.example.picknwhip_be.domain.favorite.repository;
 import com.example.picknwhip_be.domain.favorite.entity.FavoriteShop;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteShopRepository extends JpaRepository<FavoriteShop, Long> {
 
-    // 특정 유저가 특정 가게를 찜했는지 확인
-    boolean existsByUserAndShop(User user, Shop shop);
+  // 특정 유저가 특정 가게를 찜했는지 확인
+  boolean existsByUserAndShop(User user, Shop shop);
 
-    // 찜 삭제를 위해 조회
-    Optional<FavoriteShop> findByUserAndShop(User user, Shop shop);
+  // 찜 삭제를 위해 조회
+  Optional<FavoriteShop> findByUserAndShop(User user, Shop shop);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
@@ -10,6 +10,7 @@ import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository; // 유저 리포지토리 필요
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,7 +50,7 @@ public class FavoriteShopService {
     User user =
         userRepository
             .findById(userId)
-            .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 
     Shop shop =
         shopRepository

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
@@ -10,6 +10,7 @@ import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository; // 유저 리포지토리 필요
+import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class FavoriteShopService {
     User user =
         userRepository
             .findById(userId)
-            .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
     Shop shop =
         shopRepository
@@ -48,7 +49,9 @@ public class FavoriteShopService {
   /** 마이픽 가게 취소 */
   public FavoriteShopResponse removeFavoriteShop(Long userId, Long shopId) {
     User user =
-        userRepository.findById(userId).orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
     Shop shop =
         shopRepository

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
@@ -1,5 +1,7 @@
 package com.example.picknwhip_be.domain.favorite.service;
 
+import static com.example.picknwhip_be.domain.favorite.exception.code.FavoriteShopErrorCode.*;
+
 import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
 import com.example.picknwhip_be.domain.favorite.entity.FavoriteShop;
 import com.example.picknwhip_be.domain.favorite.exception.FavoriteShopException;
@@ -9,7 +11,6 @@ import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository; // 유저 리포지토리 필요
 import lombok.RequiredArgsConstructor;
-import static com.example.picknwhip_be.domain.favorite.exception.code.FavoriteShopErrorCode.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,44 +19,50 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class FavoriteShopService {
 
-    private final FavoriteShopRepository favoriteShopRepository;
-    private final ShopRepository shopRepository;
-    private final UserRepository userRepository; // 유저 조회를 위해 필요
+  private final FavoriteShopRepository favoriteShopRepository;
+  private final ShopRepository shopRepository;
+  private final UserRepository userRepository; // 유저 조회를 위해 필요
 
-    /**
-     * 마이픽 가게 등록
-     */
-    public FavoriteShopResponse addFavoriteShop(Long userId, Long shopId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
+  /** 마이픽 가게 등록 */
+  public FavoriteShopResponse addFavoriteShop(Long userId, Long shopId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
 
-        Shop shop = shopRepository.findById(shopId)
-                .orElseThrow(() -> new FavoriteShopException(SHOP_NOT_FOUND));
+    Shop shop =
+        shopRepository
+            .findById(shopId)
+            .orElseThrow(() -> new FavoriteShopException(SHOP_NOT_FOUND));
 
-        if (favoriteShopRepository.existsByUserAndShop(user, shop)) {
-            throw new FavoriteShopException(FAVORITE_ALREADY_EXISTS);
-        }
-
-        favoriteShopRepository.save(FavoriteShop.create(user, shop));
-
-        return new FavoriteShopResponse(shopId, true);
+    if (favoriteShopRepository.existsByUserAndShop(user, shop)) {
+      throw new FavoriteShopException(FAVORITE_ALREADY_EXISTS);
     }
 
-    /**
-     * 마이픽 가게 취소
-     */
-    public FavoriteShopResponse removeFavoriteShop(Long userId, Long shopId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
+    favoriteShopRepository.save(FavoriteShop.create(user, shop));
 
-        Shop shop = shopRepository.findById(shopId)
-                .orElseThrow(() -> new FavoriteShopException(SHOP_NOT_FOUND));
+    return new FavoriteShopResponse(shopId, true);
+  }
 
-        FavoriteShop favoriteShop = favoriteShopRepository.findByUserAndShop(user, shop)
-                .orElseThrow(() -> new FavoriteShopException(FAVORITE_NOT_FOUND));
+  /** 마이픽 가게 취소 */
+  public FavoriteShopResponse removeFavoriteShop(Long userId, Long shopId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
 
-        favoriteShopRepository.delete(favoriteShop);
+    Shop shop =
+        shopRepository
+            .findById(shopId)
+            .orElseThrow(() -> new FavoriteShopException(SHOP_NOT_FOUND));
 
-        return new FavoriteShopResponse(shopId, false);
-    }
+    FavoriteShop favoriteShop =
+        favoriteShopRepository
+            .findByUserAndShop(user, shop)
+            .orElseThrow(() -> new FavoriteShopException(FAVORITE_NOT_FOUND));
+
+    favoriteShopRepository.delete(favoriteShop);
+
+    return new FavoriteShopResponse(shopId, false);
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
@@ -48,9 +48,7 @@ public class FavoriteShopService {
   /** 마이픽 가게 취소 */
   public FavoriteShopResponse removeFavoriteShop(Long userId, Long shopId) {
     User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 
     Shop shop =
         shopRepository

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
@@ -1,0 +1,61 @@
+package com.example.picknwhip_be.domain.favorite.service;
+
+import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
+import com.example.picknwhip_be.domain.favorite.entity.FavoriteShop;
+import com.example.picknwhip_be.domain.favorite.exception.FavoriteShopException;
+import com.example.picknwhip_be.domain.favorite.repository.FavoriteShopRepository;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.repository.UserRepository; // 유저 리포지토리 필요
+import lombok.RequiredArgsConstructor;
+import static com.example.picknwhip_be.domain.favorite.exception.code.FavoriteShopErrorCode.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoriteShopService {
+
+    private final FavoriteShopRepository favoriteShopRepository;
+    private final ShopRepository shopRepository;
+    private final UserRepository userRepository; // 유저 조회를 위해 필요
+
+    /**
+     * 마이픽 가게 등록
+     */
+    public FavoriteShopResponse addFavoriteShop(Long userId, Long shopId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
+
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new FavoriteShopException(SHOP_NOT_FOUND));
+
+        if (favoriteShopRepository.existsByUserAndShop(user, shop)) {
+            throw new FavoriteShopException(FAVORITE_ALREADY_EXISTS);
+        }
+
+        favoriteShopRepository.save(FavoriteShop.create(user, shop));
+
+        return new FavoriteShopResponse(shopId, true);
+    }
+
+    /**
+     * 마이픽 가게 취소
+     */
+    public FavoriteShopResponse removeFavoriteShop(Long userId, Long shopId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new FavoriteShopException(USER_NOT_FOUND));
+
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new FavoriteShopException(SHOP_NOT_FOUND));
+
+        FavoriteShop favoriteShop = favoriteShopRepository.findByUserAndShop(user, shop)
+                .orElseThrow(() -> new FavoriteShopException(FAVORITE_NOT_FOUND));
+
+        favoriteShopRepository.delete(favoriteShop);
+
+        return new FavoriteShopResponse(shopId, false);
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/service/FavoriteShopService.java
@@ -9,9 +9,9 @@ import com.example.picknwhip_be.domain.favorite.repository.FavoriteShopRepositor
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.exception.UserException;
+import com.example.picknwhip_be.domain.user.exception.code.UserErrorCode;
 import com.example.picknwhip_be.domain.user.repository.UserRepository; // 유저 리포지토리 필요
-import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
-import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +30,7 @@ public class FavoriteShopService {
     User user =
         userRepository
             .findById(userId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
     Shop shop =
         shopRepository
@@ -51,7 +51,7 @@ public class FavoriteShopService {
     User user =
         userRepository
             .findById(userId)
-            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
     Shop shop =
         shopRepository

--- a/src/main/java/com/example/picknwhip_be/domain/shop/entity/Shop.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/entity/Shop.java
@@ -1,5 +1,6 @@
 package com.example.picknwhip_be.domain.shop.entity;
 
+import com.example.picknwhip_be.domain.favorite.entity.FavoriteShop;
 import com.example.picknwhip_be.domain.shop.entity.enums.ShopStatus;
 import com.example.picknwhip_be.domain.shop.entity.enums.VerificationStatus;
 import com.example.picknwhip_be.domain.shop.entity.mapping.ShopKeywordMapping;
@@ -91,6 +92,10 @@ public class Shop {
   @OneToMany(mappedBy = "shop", fetch = FetchType.LAZY)
   @Builder.Default
   private List<ShopKeywordMapping> keywordMappings = new ArrayList<>();
+
+  @OneToMany(mappedBy = "shop", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @Builder.Default
+  private List<FavoriteShop> favoriteShops = new ArrayList<>();
 
   public Shop(User owner, String shopName, String phone, Point location) {
     this.owner = owner;


### PR DESCRIPTION
## 💡 Issue
- Close #43 
  (이슈 번호를 입력하면 PR이 머지될 때 이슈가 자동으로 닫힙니다)

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 사용자가 가게를 마이픽으로 등록합니다.
- 사용자가 가게를 마이픽 취소합니다,.
- Entity favoriteShop 위치를 변경했습니다.
- 가게의 ID 와 현재 찜 상태를 응답 받습니다.
- 한 유저가 같은 가게를 중복 찜할 수 없게 막습니다.
- 특정 유저가 특정 가게를 찜했는지 확인합니다. -> 중복 할 수 없게

## 🛠️ Changes
- [x] 사용자가 가게를  마이픽 두합니다.
- [x] 사용자가 가게 마이픽을 취소합니다.

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)
**마이픽 등록**
<img width="1229" height="803" alt="스크린샷 2026-01-19 143122" src="https://github.com/user-attachments/assets/7707dabe-65c0-40b0-a98d-5800e0bdb949" />
<img width="1222" height="692" alt="스크린샷 2026-01-19 143130" src="https://github.com/user-attachments/assets/73c17d60-08b6-43f2-9fab-761064b6f3d1" />

**마이픽 취소**
<img width="1230" height="781" alt="스크린샷 2026-01-19 143235" src="https://github.com/user-attachments/assets/eacd7607-72f8-420e-85dc-0438df31ae56" />
<img width="1203" height="696" alt="스크린샷 2026-01-19 143242" src="https://github.com/user-attachments/assets/7dcb44e4-7b48-4382-a116-f6a20d821a4e" />

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?