### PR TITLE
[FEAT/#31] S3 presigned url 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           DB_URL: ${{ secrets.DB_URL }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
   # 배포 Job (Push일 때만 실행 = 머지 되었을 때)
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,4 +61,6 @@ jobs:
               -Dspring.datasource.username=admin \
               -Dspring.datasource.password=${{ secrets.DB_PASSWORD }} \
               -Dspring.jpa.hibernate.ddl-auto=update \
+              -Daws.region=ap-northeast-2 \
+              -Daws.s3.bucket=${{ secrets.S3_BUCKET }} \
               /home/ubuntu/app/*.jar > nohup.out 2>&1 &

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 
 	runtimeOnly 'com.h2database:h2'
+
+    // AWS SDK v2 (S3)
+    implementation platform('software.amazon.awssdk:bom:2.25.70')
+    implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
     // AWS SDK v2 (S3)
-    implementation platform('software.amazon.awssdk:bom:2.25.70')
+    implementation platform('software.amazon.awssdk:bom:2.41.10')
     implementation 'software.amazon.awssdk:s3'
 }
 

--- a/src/main/java/com/example/picknwhip_be/config/S3Config.java
+++ b/src/main/java/com/example/picknwhip_be/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.example.picknwhip_be.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+  @Bean
+  public S3Presigner s3Presigner(@Value("${aws.region:ap-northeast-2}") String region) {
+    return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+
+  @Bean
+  public S3Client s3Client(@Value("${aws.region:ap-northeast-2}") String region) {
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/config/S3Config.java
+++ b/src/main/java/com/example/picknwhip_be/config/S3Config.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 public class S3Config {
 
   @Bean
-  public S3Presigner s3Presigner(@Value("${aws.region:ap-northeast-2}") String region) {
+  public S3Presigner s3Presigner(@Value("${cloud.aws.region:ap-northeast-2}") String region) {
     return S3Presigner.builder()
         .region(Region.of(region))
         .credentialsProvider(DefaultCredentialsProvider.create())
@@ -21,7 +21,7 @@ public class S3Config {
 
   // 추후 이미지 삭제, 존재 확인 등 S3 직접 조작 기능 추가 시 사용 예정
   @Bean
-  public S3Client s3Client(@Value("${aws.region:ap-northeast-2}") String region) {
+  public S3Client s3Client(@Value("${cloud.aws.region:ap-northeast-2}") String region) {
     return S3Client.builder()
         .region(Region.of(region))
         .credentialsProvider(DefaultCredentialsProvider.create())

--- a/src/main/java/com/example/picknwhip_be/config/S3Config.java
+++ b/src/main/java/com/example/picknwhip_be/config/S3Config.java
@@ -19,6 +19,7 @@ public class S3Config {
         .build();
   }
 
+  // 추후 이미지 삭제, 존재 확인 등 S3 직접 조작 기능 추가 시 사용 예정
   @Bean
   public S3Client s3Client(@Value("${aws.region:ap-northeast-2}") String region) {
     return S3Client.builder()

--- a/src/main/java/com/example/picknwhip_be/domain/S3/controller/S3Controller.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/controller/S3Controller.java
@@ -1,0 +1,41 @@
+package com.example.picknwhip_be.domain.S3.controller;
+
+import com.example.picknwhip_be.domain.S3.dto.req.S3ReqDTO;
+import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
+import com.example.picknwhip_be.domain.S3.service.S3Service;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "S3", description = "이미지 업로드 API")
+@RestController
+@RequestMapping("/api/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+  private final S3Service s3Service;
+
+  @Operation(
+      summary = "단일 presigned URL 생성 by 슝/하승연",
+      description = "단일 이미지 업로드용(프로필 사진) presigned URL을 생성하는 기능입니다.")
+  @PostMapping("/upload")
+  public ApiResponse<S3ResDTO.PresignResponseDTO> createSingleUploadUrl(
+      @RequestBody @Valid S3ReqDTO.SingleDTO request) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, s3Service.createProfileUploadUrl(request.fileName()));
+  }
+
+  @Operation(
+      summary = "다중 presigned URL 생성 by 슝/하승연",
+      description = "다중 이미지 업로드용(리뷰 사진) presigned URL을 생성하는 기능입니다.")
+  @PostMapping("/upload/list")
+  public ApiResponse<List<S3ResDTO.PresignResponseDTO>> createUploadUrlList(
+      @RequestBody @Valid S3ReqDTO.BatchDTO request) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, s3Service.createReviewUploadUrls(request.fileNames()));
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/S3/dto/req/S3ReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/dto/req/S3ReqDTO.java
@@ -1,0 +1,20 @@
+package com.example.picknwhip_be.domain.S3.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public class S3ReqDTO {
+  // 단일 요청 DTO
+  public record SingleDTO(
+      @Schema(description = "이미지 파일명", example = "1.jpg") @NotBlank String fileName) {}
+
+  // 다중 요청 DTO
+  public record BatchDTO(
+      @Schema(description = "이미지 파일명 리스트", example = "[\"1.jpg\", \"2.jpg\"]")
+          @NotEmpty
+          @Size(max = 5)
+          List<String> fileNames) {}
+}

--- a/src/main/java/com/example/picknwhip_be/domain/S3/dto/req/S3ReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/dto/req/S3ReqDTO.java
@@ -16,5 +16,5 @@ public class S3ReqDTO {
       @Schema(description = "이미지 파일명 리스트", example = "[\"1.jpg\", \"2.jpg\"]")
           @NotEmpty
           @Size(max = 5)
-          List<String> fileNames) {}
+          List<@NotBlank String> fileNames) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/S3/dto/res/S3ResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/dto/res/S3ResDTO.java
@@ -1,0 +1,12 @@
+package com.example.picknwhip_be.domain.S3.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class S3ResDTO {
+  public record PresignResponseDTO(
+      @Schema(description = "저장 경로", example = "review/.../1.jpg") String keyName,
+      @Schema(
+              description = "presigned url",
+              example = "https://picknwhip.s3.ap-northeast-2.amazonaws.com/review/.../1.jpg?...")
+          String url) {}
+}

--- a/src/main/java/com/example/picknwhip_be/domain/S3/exception/S3CustomException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/exception/S3CustomException.java
@@ -3,8 +3,8 @@ package com.example.picknwhip_be.domain.S3.exception;
 import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 
-public class S3Exception extends GeneralException {
-  public S3Exception(BaseErrorCode code) {
+public class S3CustomException extends GeneralException {
+  public S3CustomException(BaseErrorCode code) {
     super(code);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/S3/exception/S3Exception.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/exception/S3Exception.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.S3.exception;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+
+public class S3Exception extends GeneralException {
+  public S3Exception(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/S3/exception/code/S3ErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/exception/code/S3ErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.picknwhip_be.domain.S3.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum S3ErrorCode implements BaseErrorCode {
+  TOO_MANY_FILES(HttpStatus.BAD_REQUEST, "S3400_1", "업로드 가능한 파일 개수를 초과했습니다."),
+
+  INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "S3400_2", "유효하지 않은 파일 이름입니다."),
+
+  PRESIGNED_URL_GENERATION_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "S3500_1", "파일 업로드 URL 생성에 실패했습니다."),
+
+  AWS_SDK_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3500_2", "AWS 서비스와 통신 중 오류가 발생했습니다."),
+
+  S3_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3500_3", "S3 처리 중 오류가 발생했습니다."),
+
+  S3_BUCKET_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, "S3500_4", "S3 버킷 설정이 올바르지 않습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -27,7 +27,7 @@ public class S3Service {
 
   private final S3Presigner s3Presigner;
 
-  @Value("${s3.bucket}")
+  @Value("${cloud.aws.s3.bucket}")
   private String bucket;
 
   // 단일 이미지 업로드용(프로필 사진) presigned URL을 발급

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -1,7 +1,7 @@
 package com.example.picknwhip_be.domain.S3.service;
 
 import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
-import com.example.picknwhip_be.domain.S3.exception.S3Exception;
+import com.example.picknwhip_be.domain.S3.exception.S3CustomException;
 import com.example.picknwhip_be.domain.S3.exception.code.S3ErrorCode;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -14,6 +14,7 @@ import org.springframework.util.StringUtils;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -45,8 +46,11 @@ public class S3Service {
   public List<S3ResDTO.PresignResponseDTO> createReviewUploadUrls(List<String> fileNames) {
     validateBucketConfigured();
 
+    if (fileNames == null) {
+      throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
+    }
     if (fileNames.size() > 5) {
-      throw new S3Exception(S3ErrorCode.TOO_MANY_FILES);
+      throw new S3CustomException(S3ErrorCode.TOO_MANY_FILES);
     }
 
     List<S3ResDTO.PresignResponseDTO> result = new ArrayList<>();
@@ -77,11 +81,11 @@ public class S3Service {
       return presigned.url().toString();
 
     } catch (S3Exception e) {
-      throw new S3Exception(S3ErrorCode.S3_OPERATION_FAILED);
+      throw new S3CustomException(S3ErrorCode.S3_OPERATION_FAILED);
     } catch (SdkClientException e) {
-      throw new S3Exception(S3ErrorCode.AWS_SDK_CLIENT_ERROR);
+      throw new S3CustomException(S3ErrorCode.AWS_SDK_CLIENT_ERROR);
     } catch (Exception e) {
-      throw new S3Exception(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
+      throw new S3CustomException(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
     }
   }
 
@@ -98,31 +102,31 @@ public class S3Service {
       return presigned.url().toString();
 
     } catch (S3Exception e) {
-      throw new S3Exception(S3ErrorCode.S3_OPERATION_FAILED);
+      throw new S3CustomException(S3ErrorCode.S3_OPERATION_FAILED);
 
     } catch (SdkClientException e) {
-      throw new S3Exception(S3ErrorCode.AWS_SDK_CLIENT_ERROR);
+      throw new S3CustomException(S3ErrorCode.AWS_SDK_CLIENT_ERROR);
 
     } catch (Exception e) {
-      throw new S3Exception(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
+      throw new S3CustomException(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
     }
   }
 
   private void validateBucketConfigured() {
     if (!StringUtils.hasText(bucket)) {
-      throw new S3Exception(S3ErrorCode.S3_BUCKET_NOT_CONFIGURED);
+      throw new S3CustomException(S3ErrorCode.S3_BUCKET_NOT_CONFIGURED);
     }
   }
 
   private void validateFileName(String fileName) {
     if (!StringUtils.hasText(fileName)) {
-      throw new S3Exception(S3ErrorCode.INVALID_FILE_NAME);
+      throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
     }
   }
 
   private void validateKeyName(String keyName) {
     if (!StringUtils.hasText(keyName)) {
-      throw new S3Exception(S3ErrorCode.INVALID_FILE_NAME);
+      throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
     }
   }
 
@@ -148,7 +152,7 @@ public class S3Service {
     }
 
     if (!StringUtils.hasText(filename)) {
-      throw new S3Exception(S3ErrorCode.INVALID_FILE_NAME);
+      throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
     }
     return filename;
   }

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -4,7 +4,6 @@ import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
 import com.example.picknwhip_be.domain.S3.exception.S3CustomException;
 import com.example.picknwhip_be.domain.S3.exception.code.S3ErrorCode;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -49,16 +49,15 @@ public class S3Service {
       throw new S3Exception(S3ErrorCode.TOO_MANY_FILES);
     }
 
-    List<S3ResDTO.PresignResponseDTO> result = new ArrayList<>();
-    for (String fileName : fileNames) {
-      validateFileName(fileName);
-
-      String keyName = buildKey("review", fileName);
-      String url = presignPutUrl(keyName);
-
-      result.add(new S3ResDTO.PresignResponseDTO(keyName, url));
-    }
-    return result;
+    return fileNames.stream()
+        .map(
+            fileName -> {
+              validateFileName(fileName);
+              String keyName = buildKey("review", fileName);
+              String url = presignPutUrl(keyName);
+              return new S3ResDTO.PresignResponseDTO(keyName, url);
+            })
+        .toList();
   }
 
   // keyName을 받아서 조회 가능한 Presigned URL을 발급

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -1,0 +1,155 @@
+package com.example.picknwhip_be.domain.S3.service;
+
+import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
+import com.example.picknwhip_be.domain.S3.exception.S3Exception;
+import com.example.picknwhip_be.domain.S3.exception.code.S3ErrorCode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+  private static final Duration UPLOAD_EXPIRES = Duration.ofMinutes(10);
+  private static final Duration DOWNLOAD_EXPIRES = Duration.ofMinutes(10);
+
+  private final S3Presigner s3Presigner;
+
+  @Value("${s3.bucket}")
+  private String bucket;
+
+  // 단일 이미지 업로드용(프로필 사진) presigned URL을 발급
+  public S3ResDTO.PresignResponseDTO createProfileUploadUrl(String fileName) {
+    validateBucketConfigured();
+    validateFileName(fileName);
+
+    String keyName = buildKey("profile", fileName);
+    String url = presignPutUrl(keyName);
+
+    return new S3ResDTO.PresignResponseDTO(keyName, url);
+  }
+
+  // 다중 이미지 업로드용(리뷰 사진) presigned URL을 발급
+  public List<S3ResDTO.PresignResponseDTO> createReviewUploadUrls(List<String> fileNames) {
+    validateBucketConfigured();
+
+    if (fileNames.size() > 5) {
+      throw new S3Exception(S3ErrorCode.TOO_MANY_FILES);
+    }
+
+    List<S3ResDTO.PresignResponseDTO> result = new ArrayList<>();
+    for (String fileName : fileNames) {
+      validateFileName(fileName);
+
+      String keyName = buildKey("review", fileName);
+      String url = presignPutUrl(keyName);
+
+      result.add(new S3ResDTO.PresignResponseDTO(keyName, url));
+    }
+    return result;
+  }
+
+  // keyName을 받아서 조회 가능한 Presigned URL을 발급
+  public String createPresignedDownloadUrl(String keyName) {
+    validateBucketConfigured();
+    validateKeyName(keyName);
+
+    try {
+      GetObjectRequest getObjectRequest =
+          GetObjectRequest.builder().bucket(bucket).key(keyName).build();
+
+      PresignedGetObjectRequest presigned =
+          s3Presigner.presignGetObject(
+              r -> r.signatureDuration(DOWNLOAD_EXPIRES).getObjectRequest(getObjectRequest));
+
+      return presigned.url().toString();
+
+    } catch (S3Exception e) {
+      throw new S3Exception(S3ErrorCode.S3_OPERATION_FAILED);
+    } catch (SdkClientException e) {
+      throw new S3Exception(S3ErrorCode.AWS_SDK_CLIENT_ERROR);
+    } catch (Exception e) {
+      throw new S3Exception(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
+    }
+  }
+
+  // keyName으로 presigned URL을 발급하는 로직
+  private String presignPutUrl(String keyName) {
+    PutObjectRequest putObjectRequest =
+        PutObjectRequest.builder().bucket(bucket).key(keyName).build();
+
+    try {
+      PresignedPutObjectRequest presigned =
+          s3Presigner.presignPutObject(
+              r -> r.signatureDuration(UPLOAD_EXPIRES).putObjectRequest(putObjectRequest));
+
+      return presigned.url().toString();
+
+    } catch (S3Exception e) {
+      throw new S3Exception(S3ErrorCode.S3_OPERATION_FAILED);
+
+    } catch (SdkClientException e) {
+      throw new S3Exception(S3ErrorCode.AWS_SDK_CLIENT_ERROR);
+
+    } catch (Exception e) {
+      throw new S3Exception(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
+    }
+  }
+
+  private void validateBucketConfigured() {
+    if (!StringUtils.hasText(bucket)) {
+      throw new S3Exception(S3ErrorCode.S3_BUCKET_NOT_CONFIGURED);
+    }
+  }
+
+  private void validateFileName(String fileName) {
+    if (!StringUtils.hasText(fileName)) {
+      throw new S3Exception(S3ErrorCode.INVALID_FILE_NAME);
+    }
+  }
+
+  private void validateKeyName(String keyName) {
+    if (!StringUtils.hasText(keyName)) {
+      throw new S3Exception(S3ErrorCode.INVALID_FILE_NAME);
+    }
+  }
+
+  // S3 keyName 만들기
+  private String buildKey(String folder, String originalFilename) {
+    String safeName = sanitizeFilename(originalFilename);
+    String uuid = UUID.randomUUID().toString();
+    return folder + "/" + uuid + "/" + safeName;
+  }
+
+  // 위험한 파일명 정리
+  private String sanitizeFilename(String originalFilename) {
+    String filename = StringUtils.cleanPath(originalFilename);
+    filename = filename.replace("\\", "/");
+
+    while (filename.contains("..")) {
+      filename = filename.replace("..", "");
+    }
+
+    int lastSlash = filename.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      filename = filename.substring(lastSlash + 1);
+    }
+
+    if (!StringUtils.hasText(filename)) {
+      throw new S3Exception(S3ErrorCode.INVALID_FILE_NAME);
+    }
+    return filename;
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,9 @@ springdoc:
     path: /v3/api-docs
   swagger-ui:
     enabled: ${SWAGGER_ENABLED:true}
+
+cloud:
+  aws:
+    region: ${AWS_REGION:ap-northeast-2}
+    s3:
+      bucket: ${S3_BUCKET}


### PR DESCRIPTION
## 💡 Issue
- Close #31 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- AWS S3 버킷 생성 및 전용 IAM Role 구성 후 EC2에 권한 주입
- AWS SDK(v2) 기반 S3 연동 의존성 추가 및 관련 설정 (build.gradle, application.yml)
- 로컬 환경(AWS Profile) 과 배포 환경(IAM Role)을 모두 고려한 자격증명 전략으로 S3Config 구성
- S3 presigned URL 발급을 위한 Request / Response DTO 설계
- S3Service에서 PUT 방식 presigned upload URL 발급 로직 구현 (단건 / 다건)
- GET 방식 presigned download URL 발급 로직 구현 (비즈니스 서비스 내부 사용 목적)
- 클라이언트 요청 검증 및 S3 연동 실패 상황을 고려한 S3 전용 ErrorCode 및 GeneralException 기반 예외 처리 적용
- S3Controller에서 프로필 이미지 업로드(단일) 및 리뷰 이미지 업로드(다중, 최대 5개)를 위한 presigned URL 발급 API 구현
- 프론트엔드 개발을 고려한 Swagger 문서화 적용
- 깃허브 액션 서버 실행 시 S3를 포함하도록 추가

flow는 다음과 같습니다.
- 클라이언트가 fileName 또는 fileNames를 API에 전달합니다.
- 서버는 fileName을 이용해 S3 저장 경로인 keyName을 각각 생성하고, 해당 key에 대한 presigned PUT URL을 각각 발급하여 keyName과 url을 클라이언트에게 반환합니다.
- 클라이언트는 발급받은 url로 S3에 직접 PUT 업로드합니다.
- 업로드가 성공하면, 클라이언트는 이후 비즈니스 API(프로필 수정, 리뷰 등록 등) 요청 시 keyName을 함께 전달해야 하고, 서버는 keyName만 DB에 저장합니다.
- 조회 시 서버는 DB에 저장된 keyName을 이용해 presigned GET URL을 생성합니다.
- 서버는 비즈니스 응답 DTO에 imageUrl(presigned GET URL)을 포함하여 반환하고, 클라이언트는 해당 URL을 `<img src="...">` 등으로 사용해 이미지를 표시합니다.

## 🛠️ Changes
- [x] POST /api/s3/upload
- [x] POST /api/s3/upload/list

## 📸 Screenshots
1. S3 로직
<img width="1024" height="729" alt="s3 로직" src="https://github.com/user-attachments/assets/023edad8-e5c4-4c8d-8b56-8fbedfde4a79" />
2. Swagger
<img width="2880" height="4863" alt="s3 swagger" src="https://github.com/user-attachments/assets/5838b792-0b12-4e1d-978e-c753eec9f49f" />
3. AWS S3 버킷
<img src = "https://github.com/user-attachments/assets/bff7b309-7dab-4cb6-becd-6a4c68b2f4c7" />

## 🔗 참고한 글
https://cn-c.tistory.com/119#google_vignette
https://pgmjun.tistory.com/163
https://sjh9708.tistory.com/259#google_vignette
보통 첫번째 글과 같이 application.yml에 credential을 환경 변수 처리하여 액세스 키와 시크릿 키를 작성하며, 이 경우 간단히 개발할 수 있지만 유출될 경우 보안 위험이 크기 때문에 저는 이 방법을 사용하지 않고, 세번째 글을 가장 많이 참고하여 직접 개발하였습니다.
이때 배포 환경과 로컬 개발 환경에서 모두 작동하도록 하기 위해, 배포 환경에서는 EC2 인스턴스에 IAM Role을 부여하여 S3 접근 권한을 관리하도록 하고, 어플리케이션은 AWS SDK가 EC2 메타데이터에서 Role 자격증명을 자동으로 획득하여 사용하도록 하였습니다.
또한 로컬 환경에서는 개별 PC에 AWS Profile을 생성해두면, 어플리케이션이 해당 프로필을 참조하여 인증하도록 하여 키를 저장소에 안 남기도록 하였습니다.
따라서 이미지 관련 담당자께서는 개발 환경에서 AWS CLI를 설치하고, AWS 사용자를 이용하여 Profile을 만든 뒤 개발하시면 됩니다.

**env 파일에 S3_BUCKET이 추가되었습니다. (노션 참고)**

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?