### PR TITLE
[FEAT/#46] 카카오 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -68,12 +68,15 @@ public class UserRestController {
   public ApiResponse<String> createLogout(HttpServletRequest request) {
     // TODO: SecurityContext 연동 필요 (현재는 임시 1L 사용)
     Long userId = 1L;
-    // 카카오 서버 로그아웃
-    userCommandService.logout(userId);
-    // 우리 서버 세션 무효화
-    HttpSession session = request.getSession(false);
-    if (session != null) {
-      session.invalidate();
+    try {
+      // 카카오 서버 로그아웃
+      userCommandService.logout(userId);
+    } finally {
+      // 우리 서버 세션 무효화
+      HttpSession session = request.getSession(false);
+      if (session != null) {
+        session.invalidate();
+      }
     }
     return ApiResponse.of(GeneralSuccessCode.OK, "로그아웃 되었습니다.");
   }

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -10,6 +10,8 @@ import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -59,5 +61,20 @@ public class UserRestController {
     Long userId = 1L;
     userCommandService.withdrawMember(userId, request);
     return ApiResponse.of(GeneralSuccessCode.OK, "탈퇴가 정상적으로 처리되었습니다.");
+  }
+
+  @Operation(summary = "로그아웃 API", description = "서버 세션을 만료시키고 카카오 로그아웃을 수행합니다.")
+  @PostMapping("/logout")
+  public ApiResponse<String> createLogout(HttpServletRequest request) {
+    // TODO: SecurityContext 연동 필요 (현재는 임시 1L 사용)
+    Long userId = 1L;
+    // 카카오 서버 로그아웃
+    userCommandService.logout(userId);
+    // 우리 서버 세션 무효화
+    HttpSession session = request.getSession(false);
+    if (session != null) {
+      session.invalidate();
+    }
+    return ApiResponse.of(GeneralSuccessCode.OK, "로그아웃 되었습니다.");
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandService.java
@@ -12,4 +12,6 @@ public interface UserCommandService {
   User updateProfile(Long userId, UserRequestDTO.UpdateProfileDTO request);
 
   void withdrawMember(Long userId, UserRequestDTO.WithdrawalDTO request);
+
+  void logout(Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -11,8 +11,13 @@ import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,8 @@ public class UserCommandServiceImpl implements UserCommandService {
   private final UserRepository userRepository;
   private final UserWithdrawalRepository userWithdrawalRepository;
   private final WithdrawalReasonItemRepository reasonItemRepository;
+  private final OAuth2AuthorizedClientService authorizedClientService;
+  private final RestTemplate restTemplate = new RestTemplate();
   private static final int MAX_NICKNAME_GENERATION_ATTEMPTS = 20;
 
   // TODO: 프로필 사진 기본 이미지 설정 구현
@@ -127,5 +134,32 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     // 직접 상태를 변경하는 대신 Repository의 delete를 호출
     userRepository.delete(user);
+  }
+
+  @Override
+  public void logout(Long userId) {
+    // DB에서 유저의 kakaoId를 가져옴
+    User user = userRepository.findById(userId)
+            .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+    // 서버 세션에 저장된 카카오 전용 클라이언트 정보를 kakao_id로 매핑했으므로 이를 사용함
+    OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+            "kakao", user.getKakaoId().toString());
+
+    if (client != null && client.getAccessToken() != null) {
+      String accessToken = client.getAccessToken().getTokenValue();
+
+      // 카카오 로그아웃 API 호출
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Authorization", "Bearer " + accessToken);
+      HttpEntity<String> entity = new HttpEntity<>(headers);
+
+      try {
+        restTemplate.postForEntity("https://kapi.kakao.com/v1/user/logout", entity, String.class);
+        // 서버 내 보관 중인 클라이언트 정보 삭제
+        authorizedClientService.removeAuthorizedClient("kakao", user.getKakaoId().toString());
+      } catch (Exception e) {
+      }
+    }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -11,12 +11,12 @@ import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
 import org.springframework.http.HttpEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -139,12 +139,14 @@ public class UserCommandServiceImpl implements UserCommandService {
   @Override
   public void logout(Long userId) {
     // DB에서 유저의 kakaoId를 가져옴
-    User user = userRepository.findById(userId)
+    User user =
+        userRepository
+            .findById(userId)
             .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
     // 서버 세션에 저장된 카카오 전용 클라이언트 정보를 kakao_id로 매핑했으므로 이를 사용함
-    OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
-            "kakao", user.getKakaoId().toString());
+    OAuth2AuthorizedClient client =
+        authorizedClientService.loadAuthorizedClient("kakao", user.getKakaoId().toString());
 
     if (client != null && client.getAccessToken() != null) {
       String accessToken = client.getAccessToken().getTokenValue();

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -11,14 +11,17 @@ import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.http.HttpEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -138,30 +141,35 @@ public class UserCommandServiceImpl implements UserCommandService {
 
   @Override
   public void logout(Long userId) {
-    // DB에서 유저의 kakaoId를 가져옴
     User user =
         userRepository
             .findById(userId)
             .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
-    // 서버 세션에 저장된 카카오 전용 클라이언트 정보를 kakao_id로 매핑했으므로 이를 사용함
     OAuth2AuthorizedClient client =
         authorizedClientService.loadAuthorizedClient("kakao", user.getKakaoId().toString());
 
     if (client != null && client.getAccessToken() != null) {
       String accessToken = client.getAccessToken().getTokenValue();
 
-      // 카카오 로그아웃 API 호출
       HttpHeaders headers = new HttpHeaders();
       headers.set("Authorization", "Bearer " + accessToken);
       HttpEntity<String> entity = new HttpEntity<>(headers);
 
       try {
+        // 카카오 로그아웃 REST API 호출
         restTemplate.postForEntity("https://kapi.kakao.com/v1/user/logout", entity, String.class);
-        // 서버 내 보관 중인 클라이언트 정보 삭제
+
+        // 성공 시 서버 내 인증 정보 삭제
         authorizedClientService.removeAuthorizedClient("kakao", user.getKakaoId().toString());
-      } catch (Exception e) {
+        log.info("카카오 로그아웃 성공. userId: {}", userId);
+
+      } catch (RestClientException e) {
+        log.error("카카오 로그아웃 API 호출 실패. userId: {}, 에러: {}", userId, e.getMessage());
+        throw new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR);
       }
+    } else {
+      log.warn("로그아웃을 시도했으나 세션에 카카오 토큰이 존재하지 않습니다. userId: {}", userId);
     }
   }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #46 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- REST API 기반의 카카오 로그아웃 기능을 구현
- 서버 측 세션 무효화하는 로직 추가

## 🛠️ Changes
- [x] 로그아웃 엔드포인트 구현 및 서버 세션 파기
- [x] 엑세스 토큰 추출하여 로그아웃 API 호출 후 토큰 만료시킴

## 📸 Screenshots
스웨거 성공 화면입니다.
<img width="588" height="606" alt="스크린샷 2026-01-19 15 34 43" src="https://github.com/user-attachments/assets/5fbd2c1c-4d35-4e08-b387-60aa1ddc8bb4" />

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?