### PR TITLE
[REFACTOR]  프로필 수정 시 전화번호 변경 기능 제거

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/req/UserRequestDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/req/UserRequestDTO.java
@@ -13,7 +13,6 @@ public class UserRequestDTO {
   @AllArgsConstructor
   public static class UpdateProfileDTO {
     private String nickname;
-    private String phone;
     private String profileImageUrl;
   }
 

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
@@ -64,12 +64,9 @@ public class User extends BaseEntity {
   }
 
   // 마이페이지 수정
-  public void updateProfile(String nickname, String phone, String profileImageUrl) {
+  public void updateProfile(String nickname, String profileImageUrl) {
     if (nickname != null && !nickname.isBlank()) {
       this.nickname = nickname;
-    }
-    if (phone != null) {
-      this.phone = phone;
     }
     if (profileImageUrl != null) {
       this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
@@ -68,7 +68,7 @@ public class User extends BaseEntity {
     if (nickname != null && !nickname.isBlank()) {
       this.nickname = nickname;
     }
-    if (profileImageUrl != null) {
+    if (profileImageUrl != null && !profileImageUrl.isBlank()) {
       this.profileImageUrl = profileImageUrl;
     }
   }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -106,7 +106,7 @@ public class UserCommandServiceImpl implements UserCommandService {
       }
     }
 
-    user.updateProfile(newNickname, request.getPhone(), request.getProfileImageUrl());
+    user.updateProfile(newNickname, request.getProfileImageUrl());
     return user;
   }
 


### PR DESCRIPTION
## 💡 Issue
- Close #55 

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [x] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 마이페이지(내 정보 수정) API에서 phone 필드를 수정할 수 없도록 변경
- 가입 시 입력한 전화번호를 고정 값으로 유지하고, 프로필 수정 시에는 닉네임과 프로필 이미지만 변경 가능

## 🛠️ Changes
- [x] UserRequestDTO.UpdateProfileDTO에서 프로필 수정 요청 객체에서 phone 필드를 제거
- [x] User 엔티티 updateProfile 메서드에서 phone 삭제
- [x] UserCommandServiceImpl에서 서비스 레이어에서 엔티티의 수정된 updateProfile 메서드 호출

## 📸 Screenshots
<img width="624" height="512" alt="스크린샷 2026-01-21 22 29 38" src="https://github.com/user-attachments/assets/dadd00dd-b0f2-40d0-90e8-e2daa8eee063" />

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?