### PR TITLE
[FEAT] 1:1 문의 이미지 기능 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -122,6 +122,27 @@ public class S3Service {
     }
   }
 
+  // 채팅 이미지 업로드용 다중 presigned URL을 발급
+  public List<S3ResDTO.PresignResponseDTO> createChatUploadUrls(
+      Long roomId, List<String> fileNames) {
+    validateBucketConfigured();
+
+    if (fileNames == null || fileNames.isEmpty()) {
+      throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
+    }
+
+    return fileNames.stream()
+        .map(
+            fileName -> {
+              validateFileName(fileName);
+              String folderPath = "chat/" + roomId;
+              String keyName = buildKey(folderPath, fileName);
+              String url = presignPutUrl(keyName);
+              return new S3ResDTO.PresignResponseDTO(keyName, url);
+            })
+        .toList();
+  }
+
   private void validateKeyName(String keyName) {
     if (!StringUtils.hasText(keyName)) {
       throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -131,6 +131,10 @@ public class S3Service {
       throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
     }
 
+    if (fileNames.size() > 5) {
+      throw new S3CustomException(S3ErrorCode.TOO_MANY_FILES);
+    }
+
     return fileNames.stream()
         .map(
             fileName -> {

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -51,14 +51,19 @@ public class ChatRestController {
 
   // S3 이미지 업로드
   @Operation(
-      summary = "채팅 이미지 업로드 URL 발급 API",
-      description = "나눠보내기를 위해 하나 또는 여러 개의 Presigned URL 리스트를 반환합니다.")
+      summary = "채팅방 이미지 전송 URL 발급 API",
+      description = "참여자 권한 확인 후 Presigned URL 리스트를 반환합니다.")
   @PostMapping("/{roomId}/images")
   public ApiResponse<List<S3ResDTO.PresignResponseDTO>> createChatImageUrls(
       @PathVariable Long roomId, @RequestBody @Valid S3ReqDTO.BatchDTO request) {
 
+    // TODO: SecurityContext 연동 필요
+    Long userId = 1L;
+
+    // 서비스 계층에서 권한 체크 및 URL 생성 수행
     List<S3ResDTO.PresignResponseDTO> result =
-        s3Service.createChatUploadUrls(roomId, request.fileNames());
+        chatCommandService.getChatImageUploadUrls(roomId, userId, request.fileNames());
+
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
 

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -57,7 +57,6 @@ public class ChatRestController {
   public ApiResponse<List<S3ResDTO.PresignResponseDTO>> createChatImageUrls(
       @PathVariable Long roomId, @RequestBody @Valid S3ReqDTO.BatchDTO request) {
 
-    // 사진이 한 장이라도 BatchDTO(리스트 형태)를 사용하면 로직
     List<S3ResDTO.PresignResponseDTO> result =
         s3Service.createChatUploadUrls(roomId, request.fileNames());
     return ApiResponse.of(GeneralSuccessCode.OK, result);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -1,5 +1,8 @@
 package com.example.picknwhip_be.domain.chat.controller;
 
+import com.example.picknwhip_be.domain.S3.dto.req.S3ReqDTO;
+import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
+import com.example.picknwhip_be.domain.S3.service.S3Service;
 import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
 import com.example.picknwhip_be.domain.chat.service.ChatCommandService;
@@ -8,6 +11,8 @@ import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class ChatRestController {
   private final ChatCommandService chatCommandService;
   private final ChatQueryService chatQueryService;
+  private final S3Service s3Service;
 
   @Operation(summary = "채팅방 생성 또는 조회 API", description = "기존 채팅방이 있으면 조회하고, 없으면 새로 생성하여 정보를 반환합니다.")
   @PostMapping
@@ -43,13 +49,19 @@ public class ChatRestController {
         GeneralSuccessCode.OK, chatQueryService.getMessages(roomId, cursor, size));
   }
 
-  // TODO: S3 이미지 업로드 로직 구현 필요
-  // @Operation(summary = "채팅 이미지 업로드 API", description = "채팅 중 전송할 이미지를 업로드하고 S3 URL을 반환받습니다.")
-  // @PostMapping("/{roomId}/images")
-  // public ApiResponse<String> createChatImage(@PathVariable Long roomId, @RequestParam("file")
-  // MultipartFile file) {
-  //    return ApiResponse.of(GeneralSuccessCode.OK, "http://temp-s3-url.com/image.jpg");
-  //  }
+  // S3 이미지 업로드
+  @Operation(
+      summary = "채팅 이미지 업로드 URL 발급 API",
+      description = "나눠보내기를 위해 하나 또는 여러 개의 Presigned URL 리스트를 반환합니다.")
+  @PostMapping("/{roomId}/images")
+  public ApiResponse<List<S3ResDTO.PresignResponseDTO>> createChatImageUrls(
+      @PathVariable Long roomId, @RequestBody @Valid S3ReqDTO.BatchDTO request) {
+
+    // 사진이 한 장이라도 BatchDTO(리스트 형태)를 사용하면 로직
+    List<S3ResDTO.PresignResponseDTO> result =
+        s3Service.createChatUploadUrls(roomId, request.fileNames());
+    return ApiResponse.of(GeneralSuccessCode.OK, result);
+  }
 
   @Operation(summary = "내 채팅방 목록 조회 API", description = "로그인한 사용자가 참여 중인 모든 채팅방 목록을 조회합니다.")
   @GetMapping

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandService.java
@@ -1,8 +1,10 @@
 package com.example.picknwhip_be.domain.chat.service;
 
+import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
 import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
 import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
+import java.util.List;
 
 public interface ChatCommandService {
   // 채팅방 생성, 기본 방 조회
@@ -10,6 +12,10 @@ public interface ChatCommandService {
 
   // 채팅 메시지 저장 및 권한 검증
   ChatMessage saveMessage(Long roomId, ChatRequestDTO.SendMessageDTO dto, Long senderId);
+
+  // 채팅 이미지 업로드 URL 발급
+  List<S3ResDTO.PresignResponseDTO> getChatImageUploadUrls(
+      Long roomId, Long userId, List<String> fileNames);
 
   // 채팅방 메시지 읽음 처리
   void updateMarkAsRead(Long roomId, Long userId);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/ChatCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.picknwhip_be.domain.chat.service;
 
+import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
+import com.example.picknwhip_be.domain.S3.service.S3Service;
 import com.example.picknwhip_be.domain.chat.converter.ChatConverter;
 import com.example.picknwhip_be.domain.chat.dto.req.ChatRequestDTO;
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
@@ -17,6 +19,7 @@ import com.example.picknwhip_be.domain.user.exception.code.UserErrorCode;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +32,7 @@ public class ChatCommandServiceImpl implements ChatCommandService {
   private final ChatMessageRepository chatMessageRepository;
   private final UserRepository userRepository;
   private final ShopRepository shopRepository;
+  private final S3Service s3Service;
 
   @Override
   public ChatResponseDTO.RoomInfo saveOrCreateRoom(ChatRequestDTO.CreateRoom dto, Long customerId) {
@@ -79,5 +83,21 @@ public class ChatCommandServiceImpl implements ChatCommandService {
   @Override
   public void updateMarkAsRead(Long roomId, Long userId) {
     chatMessageRepository.markAsReadByRoomId(roomId, userId);
+  }
+
+  @Override
+  public List<S3ResDTO.PresignResponseDTO> getChatImageUploadUrls(
+      Long roomId, Long userId, List<String> fileNames) {
+    ChatRoom room =
+        chatRoomRepository
+            .findById(roomId)
+            .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+    if (!room.getCustomer().getUserId().equals(userId)
+        && !room.getShop().getOwner().getUserId().equals(userId)) {
+      throw new ChatException(ChatErrorCode.CHAT_NOT_PARTICIPANT);
+    }
+
+    return s3Service.createChatUploadUrls(roomId, fileNames);
   }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #57 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 채팅 중 이미지를 전송할 수 있도록 S3 Presigned URL 발급 기능 추가
- 여러 장의 사진을 선택하더라도 각각 개별 메시지로 전송되는 '나눠보내기' 방식을 지원하기 위해 다중 URL 발급 구조로 구현

## 🛠️ Changes
- [x] S3Service에 chat/{roomId} 경로를 사용하여 채팅방별로 이미지를 관리할 수 있고, 하나 이상의 파일에 대해 Presigned URL을 생성하는 createChatUploadUrls 로직 구현
- [x] ChatRestController에서 S3Service를 주입받아 채팅방 이미지 전송을 위한 URL 발급 엔드포인트(POST /api/chats/{roomId}/images) 구현
- [x] STOMP 메시지 연동 확인

## 📸 Screenshots
이미지도 실시간으로 잘 전송되는 걸 볼 수 있습니다.
<img width="2065" height="693" alt="스크린샷 2026-01-21 23 05 49" src="https://github.com/user-attachments/assets/4030ee98-74b6-4a88-800d-d463d780cebb" />

DB에도 IMAGE 형태로 저장이 잘 되었습니다. 
<img width="1485" height="183" alt="스크린샷 2026-01-21 23 07 33" src="https://github.com/user-attachments/assets/0e2bd8e8-8ea4-4793-aa77-2bb1895d22df" />



## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?