### PR TITLE
[FEAT] JWT 토큰 생성 및 하드코딩 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          KAKAO_ADMIN_KEY: ${{ secrets.KAKAO_ADMIN_KEY }}
 
   # 배포 Job (Push일 때만 실행 = 머지 되었을 때)
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
           KAKAO_ADMIN_KEY: ${{ secrets.KAKAO_ADMIN_KEY }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
 
   # 배포 Job (Push일 때만 실행 = 머지 되었을 때)
   deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,10 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql'
 
 	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation platform('io.jsonwebtoken:jjwt-bom:0.13.0')
+	implementation 'io.jsonwebtoken:jjwt-api'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ dependencies {
     // flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
@@ -31,7 +31,7 @@ public class ChatController {
     ChatMessage savedMessage = chatCommandService.saveMessage(roomId, dto, senderId);
     ChatResponseDTO.MessageInfo response = ChatConverter.toMessageInfo(savedMessage);
 
-    // 채팅방 참여자들에게 메시지 실시간 브로드캐스트
+    // 채팅방 참여자들에게 메시지 브로드캐스트
     messagingTemplate.convertAndSend("/topic/chats/" + roomId, response);
 
     // 실시간 안읽은 카운트 알림 처리

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
@@ -6,6 +6,7 @@ import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
 import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.service.ChatCommandService;
 import com.example.picknwhip_be.domain.chat.service.ChatQueryService;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -20,9 +21,11 @@ public class ChatController {
   private final ChatQueryService chatQueryService;
 
   @MessageMapping("api/chats/{roomId}/messages")
-  public void sendMessage(@DestinationVariable Long roomId, ChatRequestDTO.SendMessageDTO dto) {
-    // TODO: SecurityContext 연동 (임시 1L)
-    Long senderId = 1L;
+  public void sendMessage(
+      @DestinationVariable Long roomId,
+      ChatRequestDTO.SendMessageDTO dto,
+      @ExtractPayload String userId) {
+    Long senderId = Long.parseLong(userId);
 
     // 메시지 저장 및 권한 체크
     ChatMessage savedMessage = chatCommandService.saveMessage(roomId, dto, senderId);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatController.java
@@ -24,8 +24,8 @@ public class ChatController {
   public void sendMessage(
       @DestinationVariable Long roomId,
       ChatRequestDTO.SendMessageDTO dto,
-      @ExtractPayload String userId) {
-    Long senderId = Long.parseLong(userId);
+      @ExtractPayload Long userId) {
+    Long senderId = userId;
 
     // 메시지 저장 및 권한 체크
     ChatMessage savedMessage = chatCommandService.saveMessage(roomId, dto, senderId);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -31,9 +31,8 @@ public class ChatRestController {
   @Operation(summary = "채팅방 생성 또는 조회 API", description = "기존 채팅방이 있으면 조회하고, 없으면 새로 생성하여 정보를 반환합니다.")
   @PostMapping
   public ApiResponse<ChatResponseDTO.RoomInfo> createRoom(
-      @ExtractPayload String userId, @RequestBody ChatRequestDTO.CreateRoom dto) {
-    return ApiResponse.of(
-        GeneralSuccessCode.OK, chatCommandService.saveOrCreateRoom(dto, Long.parseLong(userId)));
+      @ExtractPayload Long userId, @RequestBody ChatRequestDTO.CreateRoom dto) {
+    return ApiResponse.of(GeneralSuccessCode.OK, chatCommandService.saveOrCreateRoom(dto, userId));
   }
 
   @Operation(
@@ -43,11 +42,11 @@ public class ChatRestController {
   @GetMapping("/{roomId}/messages")
   public ApiResponse<ChatResponseDTO.MessageListDTO> getMessages(
       @PathVariable Long roomId,
-      @ExtractPayload String userId,
+      @ExtractPayload Long userId,
       @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 메시지 ID
       @RequestParam(defaultValue = "10") Integer size // 한 번에 가져올 메시지 개수
       ) {
-    chatCommandService.updateMarkAsRead(roomId, Long.parseLong(userId));
+    chatCommandService.updateMarkAsRead(roomId, userId);
     return ApiResponse.of(
         GeneralSuccessCode.OK, chatQueryService.getMessages(roomId, cursor, size));
   }
@@ -59,13 +58,12 @@ public class ChatRestController {
   @PostMapping("/{roomId}/images")
   public ApiResponse<List<S3ResDTO.PresignResponseDTO>> createChatImageUrls(
       @PathVariable Long roomId,
-      @ExtractPayload String userId,
+      @ExtractPayload Long userId,
       @RequestBody @Valid S3ReqDTO.BatchDTO request) {
 
     // 서비스 계층에서 권한 체크 및 URL 생성 수행
     List<S3ResDTO.PresignResponseDTO> result =
-        chatCommandService.getChatImageUploadUrls(
-            roomId, Long.parseLong(userId), request.fileNames());
+        chatCommandService.getChatImageUploadUrls(roomId, userId, request.fileNames());
 
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
@@ -75,12 +73,11 @@ public class ChatRestController {
       description = "로그인한 사용자가 참여 중인 채팅방 목록을 조회합니다. 가게 이름 검색 및 커서 기반 페이징을 지원합니다.")
   @GetMapping
   public ApiResponse<ChatResponseDTO.ChatRoomListDTO> getChatRoomList(
-      @ExtractPayload String userId,
+      @ExtractPayload Long userId,
       @RequestParam(required = false) String keyword,
       @RequestParam(required = false) Long cursor,
       @RequestParam(defaultValue = "10") @Min(1) @Max(50) Integer size) {
     return ApiResponse.of(
-        GeneralSuccessCode.OK,
-        chatQueryService.getChatRoomList(Long.parseLong(userId), keyword, cursor, size));
+        GeneralSuccessCode.OK, chatQueryService.getChatRoomList(userId, keyword, cursor, size));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/controller/ChatRestController.java
@@ -8,6 +8,7 @@ import com.example.picknwhip_be.domain.chat.dto.res.ChatResponseDTO;
 import com.example.picknwhip_be.domain.chat.service.ChatCommandService;
 import com.example.picknwhip_be.domain.chat.service.ChatQueryService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,9 +31,9 @@ public class ChatRestController {
   @Operation(summary = "채팅방 생성 또는 조회 API", description = "기존 채팅방이 있으면 조회하고, 없으면 새로 생성하여 정보를 반환합니다.")
   @PostMapping
   public ApiResponse<ChatResponseDTO.RoomInfo> createRoom(
-      @RequestBody ChatRequestDTO.CreateRoom dto) {
-    Long userId = 1L; // TODO: Security 연동
-    return ApiResponse.of(GeneralSuccessCode.OK, chatCommandService.saveOrCreateRoom(dto, userId));
+      @ExtractPayload String userId, @RequestBody ChatRequestDTO.CreateRoom dto) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, chatCommandService.saveOrCreateRoom(dto, Long.parseLong(userId)));
   }
 
   @Operation(
@@ -42,11 +43,11 @@ public class ChatRestController {
   @GetMapping("/{roomId}/messages")
   public ApiResponse<ChatResponseDTO.MessageListDTO> getMessages(
       @PathVariable Long roomId,
+      @ExtractPayload String userId,
       @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 메시지 ID
       @RequestParam(defaultValue = "10") Integer size // 한 번에 가져올 메시지 개수
       ) {
-    Long userId = 1L; // TODO: Security 연동
-    chatCommandService.updateMarkAsRead(roomId, userId);
+    chatCommandService.updateMarkAsRead(roomId, Long.parseLong(userId));
     return ApiResponse.of(
         GeneralSuccessCode.OK, chatQueryService.getMessages(roomId, cursor, size));
   }
@@ -57,14 +58,14 @@ public class ChatRestController {
       description = "참여자 권한 확인 후 Presigned URL 리스트를 반환합니다.")
   @PostMapping("/{roomId}/images")
   public ApiResponse<List<S3ResDTO.PresignResponseDTO>> createChatImageUrls(
-      @PathVariable Long roomId, @RequestBody @Valid S3ReqDTO.BatchDTO request) {
-
-    // TODO: SecurityContext 연동 필요
-    Long userId = 1L;
+      @PathVariable Long roomId,
+      @ExtractPayload String userId,
+      @RequestBody @Valid S3ReqDTO.BatchDTO request) {
 
     // 서비스 계층에서 권한 체크 및 URL 생성 수행
     List<S3ResDTO.PresignResponseDTO> result =
-        chatCommandService.getChatImageUploadUrls(roomId, userId, request.fileNames());
+        chatCommandService.getChatImageUploadUrls(
+            roomId, Long.parseLong(userId), request.fileNames());
 
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
@@ -74,11 +75,12 @@ public class ChatRestController {
       description = "로그인한 사용자가 참여 중인 채팅방 목록을 조회합니다. 가게 이름 검색 및 커서 기반 페이징을 지원합니다.")
   @GetMapping
   public ApiResponse<ChatResponseDTO.ChatRoomListDTO> getChatRoomList(
+      @ExtractPayload String userId,
       @RequestParam(required = false) String keyword,
       @RequestParam(required = false) Long cursor,
       @RequestParam(defaultValue = "10") @Min(1) @Max(50) Integer size) {
-    Long userId = 1L; // TODO: SecurityContext 연동
     return ApiResponse.of(
-        GeneralSuccessCode.OK, chatQueryService.getChatRoomList(userId, keyword, cursor, size));
+        GeneralSuccessCode.OK,
+        chatQueryService.getChatRoomList(Long.parseLong(userId), keyword, cursor, size));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/custom/controller/CustomController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/custom/controller/CustomController.java
@@ -29,18 +29,15 @@ public class CustomController {
       description = "사용자가 선택한 옵션으로 커스텀 케이크 주문서(임시저장)를 생성합니다.")
   @PostMapping("")
   public ApiResponse<CustomResDTO.CustomCreateDTO> postCustom(
-      @ExtractPayload String userId, @Valid @RequestBody CustomReqDTO.CustomCreateDTO dto) {
-    return ApiResponse.of(
-        GeneralSuccessCode.CREATED, customCommandService.saveCustom(Long.parseLong(userId), dto));
+      @ExtractPayload Long userId, @Valid @RequestBody CustomReqDTO.CustomCreateDTO dto) {
+    return ApiResponse.of(GeneralSuccessCode.CREATED, customCommandService.saveCustom(userId, dto));
   }
 
   @Operation(summary = "내 임시저장 목록 조회", description = "로그인한 사용자의 임시저장된 커스텀 케이크 목록을 조회합니다.")
   @GetMapping("/drafts")
-  public ApiResponse<List<CustomResDTO.GetDraftListDTO>> getDraftList(
-      @ExtractPayload String userId) {
+  public ApiResponse<List<CustomResDTO.GetDraftListDTO>> getDraftList(@ExtractPayload Long userId) {
 
-    List<CustomResDTO.GetDraftListDTO> result =
-        customQueryService.findDraftList(Long.parseLong(userId));
+    List<CustomResDTO.GetDraftListDTO> result = customQueryService.findDraftList(userId);
 
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
@@ -57,11 +54,10 @@ public class CustomController {
   @Operation(summary = "임시저장 내역 삭제", description = "특정 임시저장 주문서(draftId)를 삭제합니다.")
   @DeleteMapping("/drafts/{draftId}")
   public ApiResponse<CustomResDTO.DeleteDraftDTO> deleteDraft(
-      @ExtractPayload String userId,
+      @ExtractPayload Long userId,
       @Parameter(description = "삭제할 임시저장 ID", required = true) @PathVariable Long draftId) {
 
-    CustomResDTO.DeleteDraftDTO result =
-        customQueryService.deleteDraft(draftId, Long.parseLong(userId));
+    CustomResDTO.DeleteDraftDTO result = customQueryService.deleteDraft(draftId, userId);
 
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }

--- a/src/main/java/com/example/picknwhip_be/domain/custom/controller/CustomController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/custom/controller/CustomController.java
@@ -5,6 +5,7 @@ import com.example.picknwhip_be.domain.custom.dto.CustomResDTO;
 import com.example.picknwhip_be.domain.custom.service.CustomCommandService;
 import com.example.picknwhip_be.domain.custom.service.CustomQueryService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,16 +29,18 @@ public class CustomController {
       description = "사용자가 선택한 옵션으로 커스텀 케이크 주문서(임시저장)를 생성합니다.")
   @PostMapping("")
   public ApiResponse<CustomResDTO.CustomCreateDTO> postCustom(
-      @Valid @RequestBody CustomReqDTO.CustomCreateDTO dto) {
-    return ApiResponse.of(GeneralSuccessCode.CREATED, customCommandService.saveCustom(dto));
+      @ExtractPayload String userId, @Valid @RequestBody CustomReqDTO.CustomCreateDTO dto) {
+    return ApiResponse.of(
+        GeneralSuccessCode.CREATED, customCommandService.saveCustom(Long.parseLong(userId), dto));
   }
 
   @Operation(summary = "내 임시저장 목록 조회", description = "로그인한 사용자의 임시저장된 커스텀 케이크 목록을 조회합니다.")
   @GetMapping("/drafts")
-  public ApiResponse<List<CustomResDTO.GetDraftListDTO>> getDraftList() {
+  public ApiResponse<List<CustomResDTO.GetDraftListDTO>> getDraftList(
+      @ExtractPayload String userId) {
 
-    Long userId = 1L; // 추후 @AuthenticationPrincipal로 교체
-    List<CustomResDTO.GetDraftListDTO> result = customQueryService.findDraftList(userId);
+    List<CustomResDTO.GetDraftListDTO> result =
+        customQueryService.findDraftList(Long.parseLong(userId));
 
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
@@ -54,11 +57,11 @@ public class CustomController {
   @Operation(summary = "임시저장 내역 삭제", description = "특정 임시저장 주문서(draftId)를 삭제합니다.")
   @DeleteMapping("/drafts/{draftId}")
   public ApiResponse<CustomResDTO.DeleteDraftDTO> deleteDraft(
+      @ExtractPayload String userId,
       @Parameter(description = "삭제할 임시저장 ID", required = true) @PathVariable Long draftId) {
 
-    Long userId = 1L; // 추후 @AuthenticationPrincipal로 교체
-
-    CustomResDTO.DeleteDraftDTO result = customQueryService.deleteDraft(draftId, userId);
+    CustomResDTO.DeleteDraftDTO result =
+        customQueryService.deleteDraft(draftId, Long.parseLong(userId));
 
     return ApiResponse.of(GeneralSuccessCode.OK, result);
   }

--- a/src/main/java/com/example/picknwhip_be/domain/custom/service/CustomCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/custom/service/CustomCommandService.java
@@ -5,5 +5,5 @@ import com.example.picknwhip_be.domain.custom.dto.CustomResDTO;
 
 public interface CustomCommandService {
 
-  CustomResDTO.CustomCreateDTO saveCustom(CustomReqDTO.CustomCreateDTO dto);
+  CustomResDTO.CustomCreateDTO saveCustom(Long userId, CustomReqDTO.CustomCreateDTO dto);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/custom/service/CustomCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/custom/service/CustomCommandServiceImpl.java
@@ -17,6 +17,8 @@ import com.example.picknwhip_be.domain.shop.repository.CustomOptionRepository;
 import com.example.picknwhip_be.domain.shop.repository.ShopCakeSizeRepository;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.exception.UserException;
+import com.example.picknwhip_be.domain.user.exception.code.UserErrorCode;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +39,12 @@ public class CustomCommandServiceImpl implements CustomCommandService {
   private final UserRepository userRepository;
 
   @Override
-  public CustomResDTO.CustomCreateDTO saveCustom(CustomReqDTO.CustomCreateDTO dto) {
+  public CustomResDTO.CustomCreateDTO saveCustom(Long userId, CustomReqDTO.CustomCreateDTO dto) {
+
     User user =
-        userRepository.findById(1L).orElseThrow(() -> new RuntimeException("테스트용 1번 유저가 DB에 없음"));
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
     Shop shop =
         shopRepository

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
@@ -23,9 +23,8 @@ public class FavoriteShopController {
   @Operation(summary = "마이픽 가게 등록", description = "특정 가게를 마이픽(즐겨찾기)에 추가합니다.")
   @PostMapping("/{shopId}/favorite")
   public ApiResponse<FavoriteShopResponse> addFavoriteShop(
-      @PathVariable Long shopId, @ExtractPayload String userId) {
-    FavoriteShopResponse result =
-        favoriteShopService.addFavoriteShop(Long.parseLong(userId), shopId);
+      @PathVariable Long shopId, @ExtractPayload Long userId) {
+    FavoriteShopResponse result = favoriteShopService.addFavoriteShop(userId, shopId);
 
     return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_CREATED, result);
   }
@@ -33,9 +32,8 @@ public class FavoriteShopController {
   @Operation(summary = "마이픽 가게 취소", description = "마이픽에 등록된 가게를 삭제합니다.")
   @DeleteMapping("/{shopId}/favorite")
   public ApiResponse<FavoriteShopResponse> removeFavoriteShop(
-      @PathVariable Long shopId, @ExtractPayload String userId) {
-    FavoriteShopResponse result =
-        favoriteShopService.removeFavoriteShop(Long.parseLong(userId), shopId);
+      @PathVariable Long shopId, @ExtractPayload Long userId) {
+    FavoriteShopResponse result = favoriteShopService.removeFavoriteShop(userId, shopId);
 
     return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_DELETED, result);
   }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/controller/FavoriteShopController.java
@@ -4,6 +4,7 @@ import com.example.picknwhip_be.domain.favorite.dto.res.FavoriteShopResponse;
 import com.example.picknwhip_be.domain.favorite.exception.code.FavoriteShopSuccessCode;
 import com.example.picknwhip_be.domain.favorite.service.FavoriteShopService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +18,14 @@ public class FavoriteShopController {
 
   private final FavoriteShopService favoriteShopService;
 
-  // TODO: 실제 구현 시 userId는 토큰(Security)에서 추출해야 합니다.
-  // 테스트 편의를 위해 일단 @RequestParam으로 받거나, 하드코딩된 값(1L)을 사용한다고 가정합니다.
+  // TODO: shopId 토큰 필요
 
   @Operation(summary = "마이픽 가게 등록", description = "특정 가게를 마이픽(즐겨찾기)에 추가합니다.")
   @PostMapping("/{shopId}/favorite")
   public ApiResponse<FavoriteShopResponse> addFavoriteShop(
-      @PathVariable Long shopId, @RequestParam Long userId) {
-    FavoriteShopResponse result = favoriteShopService.addFavoriteShop(userId, shopId);
+      @PathVariable Long shopId, @ExtractPayload String userId) {
+    FavoriteShopResponse result =
+        favoriteShopService.addFavoriteShop(Long.parseLong(userId), shopId);
 
     return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_CREATED, result);
   }
@@ -32,8 +33,9 @@ public class FavoriteShopController {
   @Operation(summary = "마이픽 가게 취소", description = "마이픽에 등록된 가게를 삭제합니다.")
   @DeleteMapping("/{shopId}/favorite")
   public ApiResponse<FavoriteShopResponse> removeFavoriteShop(
-      @PathVariable Long shopId, @RequestParam Long userId) {
-    FavoriteShopResponse result = favoriteShopService.removeFavoriteShop(userId, shopId);
+      @PathVariable Long shopId, @ExtractPayload String userId) {
+    FavoriteShopResponse result =
+        favoriteShopService.removeFavoriteShop(Long.parseLong(userId), shopId);
 
     return ApiResponse.of(FavoriteShopSuccessCode.FAVORITE_DELETED, result);
   }

--- a/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
@@ -3,6 +3,7 @@ package com.example.picknwhip_be.domain.report.controller;
 import com.example.picknwhip_be.domain.report.dto.req.ReportRequestDTO;
 import com.example.picknwhip_be.domain.report.service.ReportCommandService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,10 +22,9 @@ public class ReportRestController {
   @Operation(summary = "신고하기 API", description = "로그인된 사용자가 신고를 접수합니다.")
   @PostMapping("")
   public ApiResponse<String> createReport(
-      @Valid @RequestBody ReportRequestDTO.CreateReportDTO request) {
-    // TODO: SecurityContext 연동 필요
-    Long userId = 1L;
-    reportCommandService.createReport(userId, request);
+      @ExtractPayload String userId, @Valid @RequestBody ReportRequestDTO.CreateReportDTO request) {
+
+    reportCommandService.createReport(Long.parseLong(userId), request);
     return ApiResponse.of(GeneralSuccessCode.CREATED, "신고가 접수되었습니다.");
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/controller/ReportRestController.java
@@ -22,9 +22,9 @@ public class ReportRestController {
   @Operation(summary = "신고하기 API", description = "로그인된 사용자가 신고를 접수합니다.")
   @PostMapping("")
   public ApiResponse<String> createReport(
-      @ExtractPayload String userId, @Valid @RequestBody ReportRequestDTO.CreateReportDTO request) {
+      @ExtractPayload Long userId, @Valid @RequestBody ReportRequestDTO.CreateReportDTO request) {
 
-    reportCommandService.createReport(Long.parseLong(userId), request);
+    reportCommandService.createReport(userId, request);
     return ApiResponse.of(GeneralSuccessCode.CREATED, "신고가 접수되었습니다.");
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/test/controller/TestAuthController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/test/controller/TestAuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+// TODO: 배포 시 이 파일 지우기!!!
 @Tag(name = "Test Auth", description = "테스트용 인증 API")
 @RestController
 @RequestMapping("/api/test")

--- a/src/main/java/com/example/picknwhip_be/domain/test/controller/TestAuthController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/test/controller/TestAuthController.java
@@ -1,0 +1,27 @@
+package com.example.picknwhip_be.domain.test.controller;
+
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Test Auth", description = "테스트용 인증 API")
+@RestController
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
+public class TestAuthController {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @GetMapping("/token")
+  public ApiResponse<String> getTestToken(@RequestParam Long userId) {
+
+    String token = jwtTokenProvider.createToken(userId);
+    return ApiResponse.of(GeneralSuccessCode.OK, token);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -7,6 +7,7 @@ import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.service.UserCommandService;
 import com.example.picknwhip_be.domain.user.service.UserQueryService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,51 +29,44 @@ public class UserRestController {
   @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호를 입력받아 업데이트합니다.")
   @PostMapping("/extra/info")
   public ApiResponse<String> createExtraInfo(
-      @Valid @RequestBody UserRequestDTO.ExtraInfoDTO request) {
-    // TODO: JWT 완성 후 SecurityContext에서 추출하도록 변경 필요
-    Long userId = 1L;
-    userCommandService.updateExtraInfo(userId, request);
+      @ExtractPayload String userId, @Valid @RequestBody UserRequestDTO.ExtraInfoDTO request) {
+    userCommandService.updateExtraInfo(Long.parseLong(userId), request);
     return ApiResponse.of(GeneralSuccessCode.OK, "정보 저장이 완료되었습니다.");
   }
 
   @Operation(summary = "내 정보 조회 API", description = "로그인된 사용자의 프로필 정보를 조회합니다.")
   @GetMapping("/me")
-  public ApiResponse<UserResponseDTO.UserProfileDTO> getMemberProfile() {
-    // TODO: 실제 로그인 구현 후 SecurityContext에서 ID를 가져와야 함. 현재는 임시로 1L 사용.
-    Long userId = 1L;
-    User user = userQueryService.getUser(userId);
+  public ApiResponse<UserResponseDTO.UserProfileDTO> getMemberProfile(
+      @ExtractPayload String userId) {
+    User user = userQueryService.getUser(Long.parseLong(userId));
     return ApiResponse.of(GeneralSuccessCode.OK, UserConverter.toUserProfileDTO(user));
   }
 
   @Operation(summary = "내 정보 수정 API", description = "로그인된 사용자의 정보를 수정합니다.")
   @PatchMapping("/me")
   public ApiResponse<UserResponseDTO.UpdateProfileResultDTO> updateMemberProfile(
-      @RequestBody UserRequestDTO.UpdateProfileDTO request) {
-    // TODO: SecurityContext 연동 필요
-    Long userId = 1L;
-    User user = userCommandService.updateProfile(userId, request);
+      @ExtractPayload String userId, @RequestBody UserRequestDTO.UpdateProfileDTO request) {
+    User user = userCommandService.updateProfile(Long.parseLong(userId), request);
     return ApiResponse.of(GeneralSuccessCode.OK, UserConverter.toUpdateProfileResultDTO(user));
   }
 
   @Operation(summary = "회원 탈퇴 API", description = "로그인된 사용자를 탈퇴 처리합니다.")
   @PostMapping("/withdraw")
-  public ApiResponse<String> withdrawMember(@RequestBody UserRequestDTO.WithdrawalDTO request) {
-    // TODO: SecurityContext 연동 필요
-    Long userId = 1L;
-    userCommandService.withdrawMember(userId, request);
+  public ApiResponse<String> withdrawMember(
+      @ExtractPayload String userId, @RequestBody UserRequestDTO.WithdrawalDTO request) {
+    userCommandService.withdrawMember(Long.parseLong(userId), request);
     return ApiResponse.of(GeneralSuccessCode.OK, "탈퇴가 정상적으로 처리되었습니다.");
   }
 
   @Operation(summary = "로그아웃 API", description = "서버 세션을 만료시키고 카카오 로그아웃을 수행합니다.")
   @PostMapping("/logout")
-  public ApiResponse<String> createLogout(HttpServletRequest request) {
-    // TODO: SecurityContext 연동 필요 (현재는 임시 1L 사용)
-    Long userId = 1L;
+  public ApiResponse<String> createLogout(
+      @ExtractPayload String userId, HttpServletRequest request) {
     try {
       // 카카오 서버 로그아웃
-      userCommandService.logout(userId);
+      userCommandService.logout(Long.parseLong(userId));
     } finally {
-      // 우리 서버 세션 무효화
+      // 서버 세션 무효화
       HttpSession session = request.getSession(false);
       if (session != null) {
         session.invalidate();

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -29,42 +29,40 @@ public class UserRestController {
   @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호를 입력받아 업데이트합니다.")
   @PostMapping("/extra/info")
   public ApiResponse<String> createExtraInfo(
-      @ExtractPayload String userId, @Valid @RequestBody UserRequestDTO.ExtraInfoDTO request) {
-    userCommandService.updateExtraInfo(Long.parseLong(userId), request);
+      @ExtractPayload Long userId, @Valid @RequestBody UserRequestDTO.ExtraInfoDTO request) {
+    userCommandService.updateExtraInfo(userId, request);
     return ApiResponse.of(GeneralSuccessCode.OK, "정보 저장이 완료되었습니다.");
   }
 
   @Operation(summary = "내 정보 조회 API", description = "로그인된 사용자의 프로필 정보를 조회합니다.")
   @GetMapping("/me")
-  public ApiResponse<UserResponseDTO.UserProfileDTO> getMemberProfile(
-      @ExtractPayload String userId) {
-    User user = userQueryService.getUser(Long.parseLong(userId));
+  public ApiResponse<UserResponseDTO.UserProfileDTO> getMemberProfile(@ExtractPayload Long userId) {
+    User user = userQueryService.getUser(userId);
     return ApiResponse.of(GeneralSuccessCode.OK, UserConverter.toUserProfileDTO(user));
   }
 
   @Operation(summary = "내 정보 수정 API", description = "로그인된 사용자의 정보를 수정합니다.")
   @PatchMapping("/me")
   public ApiResponse<UserResponseDTO.UpdateProfileResultDTO> updateMemberProfile(
-      @ExtractPayload String userId, @RequestBody UserRequestDTO.UpdateProfileDTO request) {
-    User user = userCommandService.updateProfile(Long.parseLong(userId), request);
+      @ExtractPayload Long userId, @RequestBody UserRequestDTO.UpdateProfileDTO request) {
+    User user = userCommandService.updateProfile(userId, request);
     return ApiResponse.of(GeneralSuccessCode.OK, UserConverter.toUpdateProfileResultDTO(user));
   }
 
   @Operation(summary = "회원 탈퇴 API", description = "로그인된 사용자를 탈퇴 처리합니다.")
   @PostMapping("/withdraw")
   public ApiResponse<String> withdrawMember(
-      @ExtractPayload String userId, @RequestBody UserRequestDTO.WithdrawalDTO request) {
-    userCommandService.withdrawMember(Long.parseLong(userId), request);
+      @ExtractPayload Long userId, @RequestBody UserRequestDTO.WithdrawalDTO request) {
+    userCommandService.withdrawMember(userId, request);
     return ApiResponse.of(GeneralSuccessCode.OK, "탈퇴가 정상적으로 처리되었습니다.");
   }
 
   @Operation(summary = "로그아웃 API", description = "서버 세션을 만료시키고 카카오 로그아웃을 수행합니다.")
   @PostMapping("/logout")
-  public ApiResponse<String> createLogout(
-      @ExtractPayload String userId, HttpServletRequest request) {
+  public ApiResponse<String> createLogout(@ExtractPayload Long userId, HttpServletRequest request) {
     try {
       // 카카오 서버 로그아웃
-      userCommandService.logout(Long.parseLong(userId));
+      userCommandService.logout(userId);
     } finally {
       // 서버 세션 무효화
       HttpSession session = request.getSession(false);

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -14,12 +14,14 @@ import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.http.HttpEntity;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -146,6 +148,9 @@ public class UserCommandServiceImpl implements UserCommandService {
     userRepository.delete(user);
   }
 
+  @Value("${kakao.admin-key}")
+  private String adminKey;
+
   @Override
   public void logout(Long userId) {
     User user =
@@ -153,30 +158,25 @@ public class UserCommandServiceImpl implements UserCommandService {
             .findById(userId)
             .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-    OAuth2AuthorizedClient client =
-        authorizedClientService.loadAuthorizedClient("kakao", user.getKakaoId().toString());
+    HttpHeaders headers = new HttpHeaders();
 
-    if (client != null && client.getAccessToken() != null) {
-      String accessToken = client.getAccessToken().getTokenValue();
+    // KakaoAK 스키마, Admin Key를 헤더에 담음
+    headers.set("Authorization", "KakaoAK " + adminKey);
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-      HttpHeaders headers = new HttpHeaders();
-      headers.set("Authorization", "Bearer " + accessToken);
-      HttpEntity<String> entity = new HttpEntity<>(headers);
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("target_id_type", "user_id");
+    params.add("target_id", user.getKakaoId().toString()); // 엔티티의 카카오 고유 ID 사용
 
-      try {
-        // 카카오 로그아웃 REST API 호출
-        restTemplate.postForEntity("https://kapi.kakao.com/v1/user/logout", entity, String.class);
+    HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
 
-        // 성공 시 서버 내 인증 정보 삭제
-        authorizedClientService.removeAuthorizedClient("kakao", user.getKakaoId().toString());
-        log.info("카카오 로그아웃 성공. userId: {}", userId);
-
-      } catch (RestClientException e) {
-        log.error("카카오 로그아웃 API 호출 실패. userId: {}, 에러: {}", userId, e.getMessage());
-        throw new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR);
-      }
-    } else {
-      log.warn("로그아웃을 시도했으나 세션에 카카오 토큰이 존재하지 않습니다. userId: {}", userId);
+    try {
+      // 카카오 로그아웃 API
+      restTemplate.postForEntity("https://kapi.kakao.com/v1/user/logout", entity, String.class);
+      log.info("카카오 서버 로그아웃 완료. userId: {}", userId);
+    } catch (RestClientException e) {
+      log.error("카카오 로그아웃 API 실패: {}", e.getMessage());
+      throw new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/annotation/ExtractPayload.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/annotation/ExtractPayload.java
@@ -1,0 +1,12 @@
+package com.example.picknwhip_be.global.apiPayload.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "username")
+public @interface ExtractPayload {}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/annotation/resolver/ExtractPayloadMessageArgumentResolver.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/annotation/resolver/ExtractPayloadMessageArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.example.picknwhip_be.global.apiPayload.annotation.resolver;
+
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExtractPayloadMessageArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    // @ExtractPayload 어노테이션이 있고 타입이 Long인 경우 지원
+    return parameter.hasParameterAnnotation(ExtractPayload.class)
+        && parameter.getParameterType().equals(Long.class);
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    Authentication authentication = (Authentication) accessor.getUser();
+
+    if (authentication == null) {
+      throw new MessageDeliveryException("인증 정보가 없습니다.");
+    }
+
+    try {
+      // JWT에서 추출되어 Principal(Name)에 저장된 String ID를 Long으로 변환
+      return Long.parseLong(authentication.getName());
+    } catch (NumberFormatException e) {
+      // 파싱 실패 시 명시적인 예외를 던져 안전하게 차단
+      throw new MessageDeliveryException("유효하지 않은 유저 ID 형식입니다.");
+    }
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/code/AuthErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/code/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.picknwhip_be.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+  LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "로그인이 필요합니다."),
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰이 만료되었습니다."),
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "유효하지 않은 토큰입니다."),
+  TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_4", "인증 헤더에 토큰이 없습니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "해당 리소스에 대한 접근 권한이 없습니다.");
+  ;
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/ChatPreHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/ChatPreHandler.java
@@ -1,0 +1,40 @@
+package com.example.picknwhip_be.global.apiPayload.config;
+
+import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatPreHandler implements ChannelInterceptor {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+    // 클라이언트가 연결하거나 메시지를 보낼 때 헤더 토큰 검증
+    if (StompCommand.CONNECT.equals(accessor.getCommand())
+        || StompCommand.SEND.equals(accessor.getCommand())) {
+      String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
+
+      if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+        String token = authorizationHeader.substring(7);
+        if (jwtTokenProvider.validateToken(token)) {
+          Authentication authentication = jwtTokenProvider.getAuthentication(token);
+          accessor.setUser(authentication); // WebSocket 세션에 인증 정보 저장
+        }
+      }
+    }
+    return message;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/ChatPreHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/ChatPreHandler.java
@@ -1,9 +1,11 @@
 package com.example.picknwhip_be.global.apiPayload.config;
 
+import com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode;
 import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -21,18 +23,28 @@ public class ChatPreHandler implements ChannelInterceptor {
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
     StompHeaderAccessor accessor =
         MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+    if (accessor == null) {
+      return message;
+    }
 
-    // 클라이언트가 연결하거나 메시지를 보낼 때 헤더 토큰 검증
     if (StompCommand.CONNECT.equals(accessor.getCommand())
         || StompCommand.SEND.equals(accessor.getCommand())) {
       String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
 
-      if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-        String token = authorizationHeader.substring(7);
-        if (jwtTokenProvider.validateToken(token)) {
-          Authentication authentication = jwtTokenProvider.getAuthentication(token);
-          accessor.setUser(authentication); // WebSocket 세션에 인증 정보 저장
-        }
+      // 헤더가 없는 경우
+      if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+        throw new MessageDeliveryException(AuthErrorCode.TOKEN_NOT_FOUND.getMessage());
+      }
+
+      String token = authorizationHeader.substring(7);
+
+      // 토큰 검증
+      if (jwtTokenProvider.validateToken(token)) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        accessor.setUser(authentication);
+      } else {
+        // 유효하지 않은 토큰
+        throw new MessageDeliveryException(AuthErrorCode.TOKEN_EXPIRED.getMessage());
       }
     }
     return message;

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.example.picknwhip_be.global.apiPayload.config;
+
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    AuthErrorCode errorCode = (AuthErrorCode) request.getAttribute("exception");
+    if (errorCode == null) {
+      errorCode = AuthErrorCode.TOKEN_NOT_FOUND;
+    }
+
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(errorCode.getStatus().value());
+
+    ApiResponse<Object> apiResponse = ApiResponse.onFailure(errorCode, null);
+    response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.example.picknwhip_be.global.apiPayload.config;
+
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getServletPath();
+    return path.startsWith("/v3/api-docs")
+        || path.startsWith("/swagger-ui")
+        || path.startsWith("/swagger-resources")
+        || path.startsWith("/webjars");
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    // JWT 토큰 추출
+    String token = resolveToken(request);
+
+    // 토큰 유효성 검사
+    try {
+      if (token != null && jwtTokenProvider.validateToken(token)) {
+        Authentication auth = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+      }
+    } catch (GeneralException e) {
+      request.setAttribute("exception", e.getCode());
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    System.out.println("DEBUG: Authorization Header: " + bearerToken);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/JwtAuthenticationFilter.java
@@ -49,7 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private String resolveToken(HttpServletRequest request) {
     String bearerToken = request.getHeader("Authorization");
-    System.out.println("DEBUG: Authorization Header: " + bearerToken);
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
       return bearerToken.substring(7);
     }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
@@ -2,44 +2,86 @@ package com.example.picknwhip_be.global.apiPayload.config;
 
 import com.example.picknwhip_be.domain.user.service.CustomOAuth2UserService;
 import com.example.picknwhip_be.global.apiPayload.handler.OAuth2AuthenticationSuccessHandler;
+import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; // 주입 확인!
   private final CustomOAuth2UserService customOAuth2UserService; // 주입
   private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler; // 주입
+  private final JwtTokenProvider jwtTokenProvider;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable) // CSRF 보안 비활성화
+
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .csrf(AbstractHttpConfigurer::disable) // CSRF 보안 비활성화
         .formLogin(AbstractHttpConfigurer::disable) // 기본 로그인 폼 비활성화
         .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .exceptionHandling(
+            exception -> exception.authenticationEntryPoint(customAuthenticationEntryPoint))
         .authorizeHttpRequests(
             authorize ->
                 authorize
-                    // Swagger UI 및 API 관련 경로는 모두 허용
-                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+                    .requestMatchers(
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/index.html",
+                        "/swagger-resources/**",
+                        "/webjars/**",
+                        "/login/**",
+                        "/oauth2/**")
                     .permitAll()
-                    // 그 외의 모든 요청은 일단 허용 (나중에 로그인이 완성되면 인증 필요로 변경)
-                    // TODO: 배포 전 반드시 authenticated()로 변경할 것
+                    .requestMatchers("/api/users/extra/info")
+                    .permitAll()
+                    .requestMatchers("/api/test/**")
+                    .permitAll() // 테스트 API 허용 추가
+
+                    // 그 외 모든 API는 인증 필요
                     .anyRequest()
-                    .permitAll())
-        // OAuth2 로그인 설정
+                    .authenticated())
         .oauth2Login(
             oauth2 ->
                 oauth2
                     .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
-                    .successHandler(oAuth2AuthenticationSuccessHandler));
+                    .successHandler(oAuth2AuthenticationSuccessHandler))
+        // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록
+        .addFilterBefore(
+            new JwtAuthenticationFilter(jwtTokenProvider),
+            UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    // Swagger UI와 로컬 프론트엔드 주소 허용
+    configuration.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:3000"));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                         "/oauth2/**")
                     .permitAll()
                     .requestMatchers("/api/users/extra/info")
-                    .permitAll()
+                    .authenticated()
                     .requestMatchers("/api/test/**")
                     .permitAll() // 테스트 API 허용 추가
 

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SwaggerConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SwaggerConfig.java
@@ -3,9 +3,8 @@ package com.example.picknwhip_be.global.apiPayload.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,14 +21,20 @@ public class SwaggerConfig {
   public OpenAPI openAPI() {
     Info info =
         new Info().title("Pick&Whip API").description("Pick&Whip 백엔드 API 문서입니다.").version("1.0.0");
+    String securitySchemeName = "bearerAuth";
 
-    // Authorize 버튼부분
-    SecurityScheme bearerAuth =
-        new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT");
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList(securitySchemeName);
 
-    return new OpenAPI()
-        .info(info)
-        .servers(List.of(new Server().url(serverUrl)))
-        .components(new Components().addSecuritySchemes("bearerAuth", bearerAuth));
+    Components components =
+        new Components()
+            .addSecuritySchemes(
+                securitySchemeName,
+                new SecurityScheme()
+                    .name(securitySchemeName)
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT"));
+
+    return new OpenAPI().info(info).addSecurityItem(securityRequirement).components(components);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
@@ -1,12 +1,17 @@
 package com.example.picknwhip_be.global.apiPayload.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.*;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final ChatPreHandler chatPreHandler;
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -20,5 +25,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     registry.enableSimpleBroker("/topic");
     // 메시지 발행 요청
     registry.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(chatPreHandler); // 인터셉터 등록
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/WebSocketConfig.java
@@ -1,7 +1,10 @@
 package com.example.picknwhip_be.global.apiPayload.config;
 
+import com.example.picknwhip_be.global.apiPayload.annotation.resolver.ExtractPayloadMessageArgumentResolver;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.*;
@@ -10,7 +13,7 @@ import org.springframework.web.socket.config.annotation.*;
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-
+  private final ExtractPayloadMessageArgumentResolver extractPayloadMessageArgumentResolver;
   private final ChatPreHandler chatPreHandler;
 
   @Override
@@ -30,5 +33,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
     registration.interceptors(chatPreHandler); // 인터셉터 등록
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+    // 웹소켓용 리졸버 등록
+    argumentResolvers.add(extractPayloadMessageArgumentResolver);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -3,6 +3,7 @@ package com.example.picknwhip_be.global.apiPayload.handler;
 import com.example.picknwhip_be.domain.user.dto.auth.KakaoUserInfo;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -11,12 +12,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
   private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
 
   @Override
   public void onAuthenticationSuccess(
@@ -32,11 +35,27 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             .findByKakaoId(kakaoId)
             .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다. kakaoId: " + kakaoId));
 
-    // 이름이나 전화번호가 없으면 무조건 추가 정보 입력 페이지로 리다이렉트
+    // JWT 토큰 생성
+    String accessToken = jwtTokenProvider.createToken(user.getUserId());
+
+    // 리다이렉트 경로 설정 및 토큰 전달
+    String targetUrl;
     if (user.getName() == null || user.getPhone() == null || user.getBirthdate() == null) {
-      getRedirectStrategy().sendRedirect(request, response, "http://localhost:3000/signup/extra");
+      // 추가 정보 입력이 필요한 경우 TODO: 프론트엔드에서 리다이렉트 주소 받기
+      targetUrl =
+          UriComponentsBuilder.fromUriString("http://localhost:3000/signup/extra")
+              .queryParam("accessToken", accessToken)
+              .build()
+              .toUriString();
     } else {
-      getRedirectStrategy().sendRedirect(request, response, "/");
+      // 이미 가입된 유저인 경우 홈으로 이동
+      targetUrl =
+          UriComponentsBuilder.fromUriString("http://localhost:3000/")
+              .queryParam("accessToken", accessToken)
+              .build()
+              .toUriString();
     }
+
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
@@ -58,9 +58,18 @@ public class JwtTokenProvider {
     try {
       Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
       return true;
-    } catch (JwtException | IllegalArgumentException e) {
-      // 유효하지 않은 토큰일 경우 false 반환
-      return false;
+    } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+      throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
+          com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
+    } catch (ExpiredJwtException e) {
+      throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
+          com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.TOKEN_EXPIRED);
+    } catch (UnsupportedJwtException e) {
+      throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
+          com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
+    } catch (IllegalArgumentException e) {
+      throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
+          com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
     }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
@@ -1,0 +1,66 @@
+package com.example.picknwhip_be.global.apiPayload.util;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+  @Value("${jwt.secret}")
+  private String secretKeyPlain;
+
+  @Value("${jwt.access-token-validity}")
+  private long tokenValidityInMilliseconds;
+
+  private SecretKey key;
+
+  @PostConstruct
+  protected void init() {
+    this.key = Keys.hmacShaKeyFor(secretKeyPlain.getBytes(StandardCharsets.UTF_8));
+  }
+
+  // 토큰 생성
+  public String createToken(Long userId) {
+    Claims claims = Jwts.claims().subject(userId.toString()).build();
+    Date now = new Date();
+    Date validity = new Date(now.getTime() + tokenValidityInMilliseconds);
+
+    return Jwts.builder().claims(claims).issuedAt(now).expiration(validity).signWith(key).compact();
+  }
+
+  // 인증 정보 조회
+  public Authentication getAuthentication(String token) {
+    String userId = getUserIdFromToken(token);
+    User principal =
+        new User(userId, "", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+    return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+  }
+
+  // 토큰에서 유저 ID 추출
+  public String getUserIdFromToken(String token) {
+    return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload().getSubject();
+  }
+
+  // 토큰 유효성 및 만료 기간 검증
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      // 유효하지 않은 토큰일 경우 false 반환
+      return false;
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "${BASE_URL:http://localhost:8080}/login/oauth2/code/kakao"
+            redirect-uri: "${BASE_URL:http://localhost:8080/login/oauth2/code/kakao}"
             scope: account_email
             client-name: Kakao
 
@@ -46,6 +46,10 @@ spring:
   application:
     name: picknwhip_be
 
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-token-validity: 3600000 # 1시간 (단위: ms)
+
 springdoc:
   server-url: ${BASE_URL:http://localhost:8080}
   api-docs:
@@ -58,3 +62,6 @@ cloud:
     region: ${AWS_REGION:ap-northeast-2}
     s3:
       bucket: ${S3_BUCKET}
+
+kakao:
+  admin-key: ${KAKAO_ADMIN_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "${BASE_URL:http://localhost:8080/login/oauth2/code/kakao}"
+            redirect-uri: "${BASE_URL:http://localhost:8080}/login/oauth2/code/kakao"
             scope: account_email
             client-name: Kakao
 


### PR DESCRIPTION
## 💡 Issue
- Close #72

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- JWT 기반 인증 시스템 구현
- 개발 단계에서 테스트의 편의성을 위한 임시토큰발급 API 추가
- 하드코딩 제거

## 🛠️ Changes
- [x] 모든 요청의 헤더에서 JWT 추출 및 검증 후 SecurityContext에 인증 정보를 JwtAuthenticationFilter에 저장
- [x] 인증되지 않은 사용자가 리소스에 접근할 때 카카오 로그인 페이지로 리다이렉트되는 대신 CustomAuthenticationEntryPoint를 도입해 401 에러 반환하도록 구현
- [x] @ExtractPayload 어노테이션으로 컨트롤러 파라미터에서 토큰 내 유저 ID를 즉시 주입
- [x] SecrurityConfig 고도화를 통해 카카오로 리다이렉트되는 대신 AuthenticationEntryPoint로 연동
- [x] ChatPreHandler로 웹소켓 연결 시에도 STOMP 헤더의 JWT 검증 가능할 수 있도록 구현
 

## 📸 Screenshots
임시 토큰 발급
<img width="1201" height="867" alt="스크린샷 2026-01-26 22 46 56" src="https://github.com/user-attachments/assets/d17d3867-0809-422f-8507-9fd7a59ef159" />

JWT 토큰 입력 후 잘 조회되는 것을 볼 수 있습니다.
<img width="1200" height="926" alt="스크린샷 2026-01-26 22 47 09" src="https://github.com/user-attachments/assets/a4df7c18-78b9-45e8-a32a-0c8d040b7061" />


## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?