### PR TITLE
[FEAT] 랜덤 닉네임 키워드별 기본 프로필 이미지 매핑 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -26,7 +26,7 @@ public class UserRestController {
   private final UserQueryService userQueryService;
   private final UserCommandService userCommandService;
 
-  @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호를 입력받아 업데이트합니다.")
+  @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호, 생일을 입력받아 업데이트합니다.")
   @PostMapping("/extra/info")
   public ApiResponse<String> createExtraInfo(
       @ExtractPayload Long userId, @Valid @RequestBody UserRequestDTO.ExtraInfoDTO request) {

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/User.java
@@ -51,11 +51,13 @@ public class User extends BaseEntity {
   private LocalDateTime deletedAt;
 
   // 카카오 최초 로그인 시 계정 생성
-  public static User createKakaoUser(Long kakaoId, String email, String nickname) {
+  public static User createKakaoUser(
+      Long kakaoId, String email, String nickname, String profileImageUrl) {
     return User.builder()
         .kakaoId(kakaoId)
         .email(email)
         .nickname(nickname)
+        .profileImageUrl(profileImageUrl)
         .status(UserStatus.ACTIVE)
         .build();
   }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -38,8 +38,11 @@ public class UserCommandServiceImpl implements UserCommandService {
   private final RestTemplate restTemplate = new RestTemplate();
   private static final int MAX_NICKNAME_GENERATION_ATTEMPTS = 20;
 
-  // TODO: 프로필 사진 기본 이미지 설정 구현
-  // private static final String DEFAULT_PROFILE_IMAGE = "//";
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Value("${cloud.aws.region:ap-northeast-2}")
+  private String region;
 
   @Override
   public User joinOrCreateUser(
@@ -55,36 +58,48 @@ public class UserCommandServiceImpl implements UserCommandService {
         .orElseGet(
             () -> {
               // 가입된 적이 없으면 랜덤 닉네임 생성 후 등록
-              String randomNickname = generateRandomNickname();
-              User newUser = User.createKakaoUser(kakaoId, email, randomNickname);
+              NicknameInfo info = generateRandomNicknameWithInfo();
+              String defaultImageUrl = constructDefaultImageUrl(info.adjective);
+              User newUser = User.createKakaoUser(kakaoId, email, info.nickname, defaultImageUrl);
               return userRepository.save(newUser);
             });
   }
 
   // 랜덤 닉네임 생성
-  private String generateRandomNickname() {
-    String[] adjectives = {"생크림", "딸기", "바닐라", "캐러멜", "쇼콜라"};
+  private record NicknameInfo(String adjective, String nickname) {}
+
+  private NicknameInfo generateRandomNicknameWithInfo() {
+    String[] adjectives = {"생크림", "딸기", "바닐라", "캐러멜", "쇼콜라"}; //
     java.util.concurrent.ThreadLocalRandom random =
         java.util.concurrent.ThreadLocalRandom.current();
 
-    // 무한 루프를 방지하기 위해 최대 시도 횟수를 제한
     for (int attempt = 0; attempt < MAX_NICKNAME_GENERATION_ATTEMPTS; attempt++) {
+      String adj = adjectives[random.nextInt(adjectives.length)];
       int randomNumber = random.nextInt(100, 1000);
-      String nickname = adjectives[random.nextInt(adjectives.length)] + randomNumber;
+      String nickname = adj + randomNumber;
 
       if (!userRepository.existsByNickname(nickname)) {
-        return nickname;
+        return new NicknameInfo(adj, nickname);
       }
     }
+    // Fallback 로직
+    return new NicknameInfo(
+        "생크림", "user_" + java.util.UUID.randomUUID().toString().substring(0, 10));
+  }
 
-    // 그래도 중복이면 UUID 기반으로 fallback (한 번만 DB 체크)
-    String fallbackNickname =
-        "user_" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 10);
-    if (!userRepository.existsByNickname(fallbackNickname)) {
-      return fallbackNickname;
-    }
-
-    throw new UserException(UserErrorCode.NICKNAME_ALREADY_EXISTS);
+  // URL 생성 헬퍼
+  private String constructDefaultImageUrl(String adjective) {
+    String fileName =
+        switch (adjective) {
+          case "생크림" -> "cream.png";
+          case "딸기" -> "strawberry.png";
+          case "바닐라" -> "vanilla.png";
+          case "캐러멜" -> "caramel.png";
+          case "쇼콜라" -> "chocolate.png";
+          default -> "base.png";
+        };
+    return String.format(
+        "https://%s.s3.%s.amazonaws.com/profile/default/%s", bucket, region, fileName);
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -72,7 +72,7 @@ public class UserCommandServiceImpl implements UserCommandService {
   private record NicknameInfo(String adjective, String nickname) {}
 
   private NicknameInfo generateRandomNicknameWithInfo() {
-    String[] adjectives = {"생크림", "딸기", "바닐라", "캐러멜", "쇼콜라"}; //
+    String[] adjectives = {"생크림", "딸기", "바닐라", "캐러멜", "쇼콜라"};
     java.util.concurrent.ThreadLocalRandom random =
         java.util.concurrent.ThreadLocalRandom.current();
 
@@ -88,9 +88,13 @@ public class UserCommandServiceImpl implements UserCommandService {
     // Fallback 로직
     String adj = "생크림";
     String nickname;
-    do {
+    for (int i = 0; i < MAX_NICKNAME_GENERATION_ATTEMPTS; i++) {
       nickname = adj + java.util.UUID.randomUUID().toString().substring(0, 10);
-    } while (userRepository.existsByNickname(nickname));
+      if (!userRepository.existsByNickname(nickname)) {
+        return new NicknameInfo(adj, nickname);
+      }
+    }
+    nickname = adj + System.currentTimeMillis();
     return new NicknameInfo(adj, nickname);
   }
 

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/UserCommandServiceImpl.java
@@ -59,8 +59,11 @@ public class UserCommandServiceImpl implements UserCommandService {
             () -> {
               // 가입된 적이 없으면 랜덤 닉네임 생성 후 등록
               NicknameInfo info = generateRandomNicknameWithInfo();
-              String defaultImageUrl = constructDefaultImageUrl(info.adjective);
-              User newUser = User.createKakaoUser(kakaoId, email, info.nickname, defaultImageUrl);
+              String resolvedImageUrl =
+                  (profileImageUrl != null && !profileImageUrl.isBlank())
+                      ? profileImageUrl
+                      : constructDefaultImageUrl(info.adjective);
+              User newUser = User.createKakaoUser(kakaoId, email, info.nickname, resolvedImageUrl);
               return userRepository.save(newUser);
             });
   }
@@ -83,8 +86,12 @@ public class UserCommandServiceImpl implements UserCommandService {
       }
     }
     // Fallback 로직
-    return new NicknameInfo(
-        "생크림", "user_" + java.util.UUID.randomUUID().toString().substring(0, 10));
+    String adj = "생크림";
+    String nickname;
+    do {
+      nickname = adj + java.util.UUID.randomUUID().toString().substring(0, 10);
+    } while (userRepository.existsByNickname(nickname));
+    return new NicknameInfo(adj, nickname);
   }
 
   // URL 생성 헬퍼


### PR DESCRIPTION
## 💡 Issue
- Close #81 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 회원가입 시 생성되는 랜덤 닉네임 키워드에 맞춰 S3에 저장된 전용 기본 프로필 이미지 URL을 자동으로 매핑하고 DB에 저장

## 🛠️ Changes
- [x] User 엔티티에서 createKakaoUser 메서드가 닉네임에 매핑된 URL을 함께 전달받아 유저를 생성하도록 로직 수정
- [x] 기존에 문자열만 반환하던 닉네임 생성 로직을 선택된 키워드 정보와 함께 반환할 수 있도록 내부 레코드 도입
- [x] 서비스에서 닉네임 키워드에 따라 S3의 profile/default/ 경로를 참조하는 최종 이미지 주소를 생성하는 메서드 추가
- [x] 최초 카카오 로그인 시 실행되는 유저 생성 과정에 이미지 매핑 로직 통합하여 DB에 프로필 경로 저장되도록 구현   

## 📸 Screenshots
카카오 로그인 후 DB에 저장된 새로운 유저의 랜덤 닉네임과 그에 맞는 기본 이미지가 매핑되어 저장됩니다.
ex) 딸기331 -> starberry
<img width="1561" height="178" alt="스크린샷 2026-01-28 21 15 41" src="https://github.com/user-attachments/assets/9b6840b0-41bd-4006-8e62-3b1e2c081d56" />

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?