### PR TITLE
[FEAT/#80] 리뷰 작성 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/PicknwhipBeApplication.java
+++ b/src/main/java/com/example/picknwhip_be/PicknwhipBeApplication.java
@@ -3,9 +3,11 @@ package com.example.picknwhip_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class PicknwhipBeApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/example/picknwhip_be/config/TimeConfig.java
+++ b/src/main/java/com/example/picknwhip_be/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.example.picknwhip_be.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.systemDefaultZone();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
+++ b/src/main/java/com/example/picknwhip_be/domain/S3/service/S3Service.java
@@ -4,6 +4,7 @@ import com.example.picknwhip_be.domain.S3.dto.res.S3ResDTO;
 import com.example.picknwhip_be.domain.S3.exception.S3CustomException;
 import com.example.picknwhip_be.domain.S3.exception.code.S3ErrorCode;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -24,7 +24,9 @@ public class S3Service {
 
   private static final Duration UPLOAD_EXPIRES = Duration.ofMinutes(10);
   private static final Duration DOWNLOAD_EXPIRES = Duration.ofMinutes(10);
+  private static final int DELETE_OBJECTS_MAX = 1000;
 
+  private final S3Client s3Client;
   private final S3Presigner s3Presigner;
 
   @Value("${cloud.aws.s3.bucket}")
@@ -178,5 +180,57 @@ public class S3Service {
       throw new S3CustomException(S3ErrorCode.INVALID_FILE_NAME);
     }
     return filename;
+  }
+
+  // 단일 이미지 삭제
+  public void deleteObject(String s3Key) {
+    if (s3Key == null || s3Key.isBlank()) {
+      return;
+    }
+
+    try {
+      s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(s3Key).build());
+    } catch (Exception e) {
+      throw new S3CustomException(S3ErrorCode.S3_OPERATION_FAILED);
+    }
+  }
+
+  // 다중 이미지 삭제
+  public void deleteObjects(List<String> s3Keys) {
+    if (s3Keys == null || s3Keys.isEmpty()) {
+      return;
+    }
+
+    List<String> filtered = s3Keys.stream().filter(k -> k != null && !k.isBlank()).toList();
+    if (filtered.isEmpty()) {
+      return;
+    }
+
+    List<List<String>> batches = split(filtered, DELETE_OBJECTS_MAX);
+    for (List<String> batch : batches) {
+      try {
+        List<ObjectIdentifier> objects =
+            batch.stream().map(k -> ObjectIdentifier.builder().key(k).build()).toList();
+
+        s3Client.deleteObjects(
+            DeleteObjectsRequest.builder()
+                .bucket(bucket)
+                .delete(Delete.builder().objects(objects).build())
+                .build());
+      } catch (Exception e) {
+        throw new S3CustomException(S3ErrorCode.S3_OPERATION_FAILED);
+      }
+    }
+  }
+
+  private List<List<String>> split(List<String> list, int size) {
+    List<List<String>> result = new ArrayList<>();
+    int i = 0;
+    while (i < list.size()) {
+      int end = Math.min(i + size, list.size());
+      result.add(list.subList(i, end));
+      i = end;
+    }
+    return result;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
@@ -1,5 +1,6 @@
 package com.example.picknwhip_be.domain.design.entity;
 
+import com.example.picknwhip_be.domain.shop.entity.Shop;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,9 +16,9 @@ public class DesignGallery {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  //    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  //    @JoinColumn(name = "shop_id", nullable = false)
-  //    private Shops shops;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "shop_id", nullable = false)
+  private Shop shop;
 
   @Column(name = "design_name", nullable = false)
   private String designName;

--- a/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepository.java
@@ -1,0 +1,6 @@
+package com.example.picknwhip_be.domain.design.repository;
+
+import com.example.picknwhip_be.domain.design.entity.DesignGallery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DesignGalleryRepository extends JpaRepository<DesignGallery, Long> {}

--- a/src/main/java/com/example/picknwhip_be/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/order/repository/OrderRepository.java
@@ -1,0 +1,6 @@
+package com.example.picknwhip_be.domain.order.repository;
+
+import com.example.picknwhip_be.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {}

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -1,0 +1,32 @@
+package com.example.picknwhip_be.domain.review.controller;
+
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+import com.example.picknwhip_be.domain.review.service.command.ReviewCommandService;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Review", description = "리뷰 API")
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+  private final ReviewCommandService reviewCommandService;
+
+  @Operation(summary = "리뷰 작성 by 슝/하승연", description = "로그인한 회원이 리뷰를 등록하는 기능입니다. ")
+  @PostMapping("/{orderId}")
+  public ApiResponse<ReviewResDTO.WriteDTO> CreateReview(
+      @PathVariable Long orderId,
+      @RequestBody @Valid ReviewReqDTO.WriteDTO dto,
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.CREATED, reviewCommandService.createReview(orderId, dto, userId));
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
   private final ReviewCommandService reviewCommandService;
 
-  @Operation(summary = "리뷰 작성 by 슝/하승연", description = "로그인한 회원이 리뷰를 등록하는 기능입니다. ")
+  @Operation(summary = "리뷰 작성 by 슝/하승연", description = "로그인한 회원이 리뷰를 등록하는 기능입니다.")
   @PostMapping("/{orderId}")
   public ApiResponse<ReviewResDTO.WriteDTO> CreateReview(
       @PathVariable Long orderId,
@@ -28,5 +28,14 @@ public class ReviewController {
       @Parameter(hidden = true) @ExtractPayload Long userId) {
     return ApiResponse.of(
         GeneralSuccessCode.CREATED, reviewCommandService.createReview(orderId, dto, userId));
+  }
+
+  @Operation(summary = "리뷰 작성 by 슝/하승연", description = "회원이 작성한 리뷰를 삭제하는 기능입니다.")
+  @DeleteMapping("/{reviewId}")
+  public ApiResponse<Void> DeleteReview(
+      @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {
+
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewCommandService.deleteReview(reviewId, userId));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -30,7 +30,7 @@ public class ReviewController {
         GeneralSuccessCode.CREATED, reviewCommandService.createReview(orderId, dto, userId));
   }
 
-  @Operation(summary = "리뷰 작성 by 슝/하승연", description = "회원이 작성한 리뷰를 삭제하는 기능입니다.")
+  @Operation(summary = "리뷰 삭제 by 슝/하승연", description = "회원이 작성한 리뷰를 삭제하는 기능입니다.")
   @DeleteMapping("/{reviewId}")
   public ApiResponse<Void> DeleteReview(
       @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -1,0 +1,24 @@
+package com.example.picknwhip_be.domain.review.converter;
+
+import com.example.picknwhip_be.domain.order.entity.Order;
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+import com.example.picknwhip_be.domain.review.entity.Review;
+
+public class ReviewConverter {
+  public static ReviewResDTO.WriteDTO toWriteDTO(Long reviewId) {
+    return ReviewResDTO.WriteDTO.builder().reviewId(reviewId).build();
+  }
+
+  public static Review toReview(Order order, ReviewReqDTO.WriteDTO dto) {
+    return Review.builder()
+        .order(order)
+        .user(order.getUser())
+        .shop(order.getShop())
+        .design(order.getDesignGallery())
+        .rating(dto.rating())
+        .content(dto.content())
+        .agreement(dto.agreement())
+        .build();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewImageConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewImageConverter.java
@@ -1,0 +1,26 @@
+package com.example.picknwhip_be.domain.review.converter;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ReviewImageConverter {
+  public static List<ReviewImage> toReviewImages(Review review, List<String> imageKeys) {
+    if (imageKeys == null || imageKeys.isEmpty()) {
+      return List.of();
+    }
+
+    AtomicInteger sortOrder = new AtomicInteger(1);
+
+    return imageKeys.stream()
+        .map(
+            key ->
+                ReviewImage.builder()
+                    .review(review)
+                    .s3Key(key)
+                    .sortOrder(sortOrder.getAndIncrement())
+                    .build())
+        .toList();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewSelectedKeywordConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewSelectedKeywordConverter.java
@@ -1,0 +1,19 @@
+package com.example.picknwhip_be.domain.review.converter;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewKeyword;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
+import java.util.List;
+
+public class ReviewSelectedKeywordConverter {
+  public static List<ReviewSelectedKeyword> toSelectedKeywords(
+      Review review, List<ReviewKeyword> keywords) {
+    if (keywords == null || keywords.isEmpty()) {
+      return List.of();
+    }
+
+    return keywords.stream()
+        .map(keyword -> ReviewSelectedKeyword.builder().review(review).keyword(keyword).build())
+        .toList();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/req/ReviewReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/req/ReviewReqDTO.java
@@ -1,0 +1,23 @@
+package com.example.picknwhip_be.domain.review.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+public class ReviewReqDTO {
+  // 리뷰 작성 DTO
+  public record WriteDTO(
+      @Schema(description = "별점(1~5의 정수)", example = "5") @NotNull @Min(1) @Max(5) Integer rating,
+      @Schema(description = "리뷰 내용(10~500자)", example = "너무 예쁘고 맛있었어요!")
+          @NotBlank
+          @Size(min = 10, max = 500)
+          String content,
+      @Schema(description = "선택된 키워드 코드(1~5개)", example = "[\"DELICIOUS\", \"CLEAN_STORE\"]")
+          @NotEmpty
+          @Size(min = 1, max = 5)
+          List<String> keywords,
+      @Schema(description = "S3에 업로드된 이미지 key 목록(최대 5장)", example = "[\"1.jpg\",  \"2.jpg\"]")
+          @Size(max = 5)
+          List<String> imageKeys,
+      @Schema(description = "옵션 공개 동의 여부", example = "true") Boolean agreement) {}
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/req/ReviewReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/req/ReviewReqDTO.java
@@ -12,7 +12,7 @@ public class ReviewReqDTO {
           @NotBlank
           @Size(min = 10, max = 500)
           String content,
-      @Schema(description = "선택된 키워드 코드(1~5개)", example = "[\"DELICIOUS\", \"CLEAN_STORE\"]")
+      @Schema(description = "선택된 키워드 코드(1~5개)", example = "[\"DELICIOUS\", \"CLEAN\"]")
           @NotEmpty
           @Size(min = 1, max = 5)
           List<String> keywords,

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.review.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+public class ReviewResDTO {
+  // 리뷰 작성 DTO
+  @Builder
+  public record WriteDTO(@Schema(description = "생성된 리뷰 ID", example = "1") Long reviewId) {}
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Builder
@@ -18,6 +19,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(name = "review")
+@SQLRestriction("deleted_at is null")
 public class Review extends BaseEntity {
 
   @Id
@@ -60,5 +62,9 @@ public class Review extends BaseEntity {
     if (this.deletedAt == null) {
       this.deletedAt = now;
     }
+  }
+
+  public boolean isDeleted() {
+    return this.deletedAt != null;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/Review.java
@@ -1,6 +1,10 @@
 package com.example.picknwhip_be.domain.review.entity;
 
+import com.example.picknwhip_be.domain.design.entity.DesignGallery;
+import com.example.picknwhip_be.domain.order.entity.Order;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -20,21 +24,21 @@ public class Review extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  //    @OneToOne(fetch = FetchType.LAZY, optional = false)
-  //    @JoinColumn(name = "order_id", nullable = false, unique = true)
-  //    private Order order;
+  @OneToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "order_id", nullable = false, unique = true)
+  private Order order;
 
-  //    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  //    @JoinColumn(name = "user_id", nullable = false)
-  //    private User user;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-  //    @ManyToOne(fetch = FetchType.LAZY)
-  //    @JoinColumn(name = "shop_id", nullable = false)
-  //    private Shops shops;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "shop_id", nullable = false)
+  private Shop shop;
 
-  //    @ManyToOne(fetch = FetchType.LAZY)
-  //    @JoinColumn(name = "design_id")
-  //    private DesignGallery design;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "design_id")
+  private DesignGallery design;
 
   @Column(name = "rating", nullable = false)
   private Integer rating;
@@ -47,6 +51,10 @@ public class Review extends BaseEntity {
 
   @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
   private List<ReviewLike> likes = new ArrayList<>();
+
+  @Column(name = "agreement")
+  @Builder.Default
+  private Boolean agreement = true;
 
   public void softDelete(LocalDateTime now) {
     if (this.deletedAt == null) {

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewImage.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewImage.java
@@ -5,6 +5,7 @@ import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Builder
@@ -12,6 +13,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(name = "review_image")
+@SQLRestriction("deleted_at is null")
 public class ReviewImage extends BaseEntity {
 
   @Id
@@ -30,10 +32,4 @@ public class ReviewImage extends BaseEntity {
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
-
-  public void softDelete(LocalDateTime now) {
-    if (this.deletedAt == null) {
-      this.deletedAt = now;
-    }
-  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewKeyword.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewKeyword.java
@@ -9,13 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Table(
-    name = "review_keyword",
-    uniqueConstraints = {
-      @UniqueConstraint(
-          name = "uk_review_keyword_category_keyword",
-          columnNames = {"category", "keyword"})
-    })
+@Table(name = "review_keyword")
 public class ReviewKeyword {
 
   @Id
@@ -26,6 +20,9 @@ public class ReviewKeyword {
   @Enumerated(EnumType.STRING)
   private KeywordCategory category;
 
-  @Column(name = "keyword", nullable = false, length = 15)
-  private String keyword;
+  @Column(name = "code", nullable = false, length = 50, unique = true)
+  private String code;
+
+  @Column(name = "label", nullable = false, length = 15)
+  private String label;
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewLike.java
@@ -1,6 +1,7 @@
 package com.example.picknwhip_be.domain.review.entity.mapping;
 
 import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,13 +12,12 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(
-    name = "review_like"
-    //    uniqueConstraints = {
-    //      @UniqueConstraint(
-    //          name = "uk_review_like_review_user",
-    //          columnNames = {"review_id", "user_id"})
-    //    }
-    )
+    name = "review_like",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_review_like_review_user",
+          columnNames = {"review_id", "user_id"})
+    })
 public class ReviewLike extends BaseEntity {
 
   @Id
@@ -28,7 +28,7 @@ public class ReviewLike extends BaseEntity {
   @JoinColumn(name = "review_id", nullable = false)
   private Review review;
 
-  //    @ManyToOne(fetch =  FetchType.LAZY, optional = false)
-  //    @JoinColumn(name = "user_id", nullable = false)
-  //    private User user;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/entity/mapping/ReviewReply.java
@@ -1,10 +1,12 @@
 package com.example.picknwhip_be.domain.review.entity.mapping;
 
 import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Builder
@@ -18,6 +20,7 @@ import lombok.*;
           name = "uk_review_reply_review",
           columnNames = {"review_id"})
     })
+@SQLRestriction("deleted_at is null")
 public class ReviewReply extends BaseEntity {
 
   @Id
@@ -28,19 +31,13 @@ public class ReviewReply extends BaseEntity {
   @JoinColumn(name = "review_id", unique = true)
   private Review review;
 
-  //    @ManyToOne(fetch = FetchType.LAZY)
-  //    @JoinColumn(name = "seller_id")
-  //    private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "seller_id")
+  private User user;
 
   @Column(name = "content", length = 500, nullable = false)
   private String content;
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
-
-  public void softDelete(LocalDateTime now) {
-    if (this.deletedAt == null) {
-      this.deletedAt = now;
-    }
-  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/ReviewException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/ReviewException.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.review.exception;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+
+public class ReviewException extends GeneralException {
+  public ReviewException(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
@@ -19,6 +19,8 @@ public enum ReviewErrorCode implements BaseErrorCode {
 
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 주문입니다."),
 
+  REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_2", "리뷰가 존재하지 않습니다."),
+
   REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW409_1", "이미 해당 주문에 대한 리뷰가 존재합니다."),
 
   REVIEW_IMAGE_VALIDATION_FAILED(

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
@@ -1,0 +1,30 @@
+package com.example.picknwhip_be.domain.review.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+  INVALID_REVIEW_IMAGE_KEY(HttpStatus.BAD_REQUEST, "REVIEW400_1", "유효하지 않은 이미지 키입니다."),
+
+  REVIEW_KEYWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "REVIEW400_2", "중복된 리뷰 키워드가 포함되어 있습니다."),
+
+  INVALID_REVIEW_KEYWORD_CODE(
+      HttpStatus.BAD_REQUEST, "REVIEW400_3", "유효하지 않은 리뷰 키워드 코드가 포함되어 있습니다."),
+
+  REVIEW_WRITE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "REVIEW403_1", "해당 주문에 대한 리뷰 작성 권한이 없습니다."),
+
+  ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 주문입니다."),
+
+  REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW409_1", "이미 해당 주문에 대한 리뷰가 존재합니다."),
+
+  REVIEW_IMAGE_VALIDATION_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "REVIEW500_1", "이미지 S3 검증 중 오류가 발생했습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewSuccessCode.java
@@ -1,0 +1,15 @@
+package com.example.picknwhip_be.domain.review.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewSuccessCode {
+  REVIEW_CREATED(HttpStatus.CREATED, "REVIEW200_1", "성공적으로 리뷰가 등록되었습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewImageRepository.java
@@ -1,0 +1,6 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewImageRepository.java
@@ -1,6 +1,35 @@
 package com.example.picknwhip_be.domain.review.repository;
 
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {}
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      """
+      update ReviewImage ri
+         set ri.deletedAt = :now
+       where ri.review.id = :reviewId
+         and ri.deletedAt is null
+      """)
+  void softDeleteAllByReviewId(@Param("reviewId") Long reviewId, @Param("now") LocalDateTime now);
+
+  @Query(
+      value =
+          """
+                    select s3_key
+                      from review_image
+                     where review_id = :reviewId
+                    """,
+      nativeQuery = true)
+  List<String> findS3KeysByReviewId(@Param("reviewId") Long reviewId);
+
+  @Modifying
+  @Query("delete from ReviewImage ri where ri.review.id = :reviewId")
+  int hardDeleteAllByReviewId(@Param("reviewId") Long reviewId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewKeywordRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewKeywordRepository.java
@@ -1,0 +1,9 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewKeyword;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewKeywordRepository extends JpaRepository<ReviewKeyword, Long> {
+  List<ReviewKeyword> findAllByCodeIn(List<String> codeList);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewLikeRepository.java
@@ -1,13 +1,13 @@
 package com.example.picknwhip_be.domain.review.repository;
 
-import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ReviewSelectedKeywordRepository
-    extends JpaRepository<ReviewSelectedKeyword, Long> {
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("delete from ReviewSelectedKeyword rsk where rsk.review.id = :reviewId")
-    int deleteByReviewId(@Param("reviewId") Long reviewId);}
+    @Query("delete from ReviewLike rl where rl.review.id = :reviewId")
+    int deleteByReviewId(@Param("reviewId") Long reviewId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewLikeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("delete from ReviewLike rl where rl.review.id = :reviewId")
-    int deleteByReviewId(@Param("reviewId") Long reviewId);
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("delete from ReviewLike rl where rl.review.id = :reviewId")
+  void deleteByReviewId(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewReplyRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewReplyRepository.java
@@ -1,0 +1,24 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewReply;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReviewReplyRepository extends JpaRepository<ReviewReply, Long> {
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      """
+      update ReviewReply rr
+         set rr.deletedAt = :now
+       where rr.review.id = :reviewId
+         and rr.deletedAt is null
+      """)
+  void softDeleteAllByReviewId(@Param("reviewId") Long reviewId, @Param("now") LocalDateTime now);
+
+  @Modifying
+  @Query("delete from ReviewReply rr where rr.review.id = :reviewId")
+  void hardDeleteAllByReviewId(@Param("reviewId") Long reviewId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+  boolean existsByOrderId(Long orderId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,29 @@
 package com.example.picknwhip_be.domain.review.repository;
 
 import com.example.picknwhip_be.domain.review.entity.Review;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
   boolean existsByOrderId(Long orderId);
+
+  @Query(
+      value =
+          """
+                    select id
+                      from review
+                     where deleted_at is not null
+                       and deleted_at < :cutoff
+                    order by id
+                    """,
+      nativeQuery = true)
+  List<Long> findPurgeTargetIds(@Param("cutoff") LocalDateTime cutoff);
+
+  @Modifying
+  @Query(value = "delete from review where id = :reviewId", nativeQuery = true)
+  int hardDeleteById(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewSelectedKeywordRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewSelectedKeywordRepository.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewSelectedKeywordRepository
+    extends JpaRepository<ReviewSelectedKeyword, Long> {}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewSelectedKeywordRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewSelectedKeywordRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewSelectedKeywordRepository
     extends JpaRepository<ReviewSelectedKeyword, Long> {
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("delete from ReviewSelectedKeyword rsk where rsk.review.id = :reviewId")
-    int deleteByReviewId(@Param("reviewId") Long reviewId);}
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("delete from ReviewSelectedKeyword rsk where rsk.review.id = :reviewId")
+  void deleteByReviewId(@Param("reviewId") Long reviewId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/scheduler/ReviewPurgeScheduler.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/scheduler/ReviewPurgeScheduler.java
@@ -1,0 +1,61 @@
+package com.example.picknwhip_be.domain.review.scheduler;
+
+import com.example.picknwhip_be.domain.S3.service.S3Service;
+import com.example.picknwhip_be.domain.review.repository.ReviewImageRepository;
+import com.example.picknwhip_be.domain.review.repository.ReviewRepository;
+import com.example.picknwhip_be.domain.review.service.command.ReviewPurgeService;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewPurgeScheduler {
+  private static final long RETENTION_DAYS = 30;
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewImageRepository reviewImageRepository;
+  private final ReviewPurgeService reviewPurgeService;
+  private final S3Service s3Service;
+  private final Clock clock;
+
+  // 매일 4:00AM에 실행
+  @Scheduled(cron = "0 0 4 * * *")
+  public void purgeDeletedReviews() {
+
+    LocalDateTime cutoff = LocalDateTime.now(clock).minusDays(RETENTION_DAYS);
+    List<Long> targetIds = reviewRepository.findPurgeTargetIds(cutoff);
+      log.warn("[ReviewPurge] start cutoff={}", cutoff);
+      log.warn("[ReviewPurge] targetIds={}", targetIds);
+
+    if (targetIds.isEmpty()) {
+      return;
+    }
+
+    int successCount = 0;
+
+    for (Long reviewId : targetIds) {
+      try {
+        List<String> s3Keys = reviewImageRepository.findS3KeysByReviewId(reviewId);
+        s3Service.deleteObjects(s3Keys);
+
+        int deleted = reviewPurgeService.hardDeleteReviewGraph(reviewId);
+        successCount += deleted;
+      } catch (Exception e) {
+        log.error("purge failed. reviewId={}", reviewId, e);
+      }
+    }
+
+    log.info(
+        "purgeDeletedReviews done. cutoff={}, targetCount={}, successCount={}",
+        cutoff,
+        targetIds.size(),
+        successCount);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/scheduler/ReviewPurgeScheduler.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/scheduler/ReviewPurgeScheduler.java
@@ -6,7 +6,6 @@ import com.example.picknwhip_be.domain.review.repository.ReviewRepository;
 import com.example.picknwhip_be.domain.review.service.command.ReviewPurgeService;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,8 +30,8 @@ public class ReviewPurgeScheduler {
 
     LocalDateTime cutoff = LocalDateTime.now(clock).minusDays(RETENTION_DAYS);
     List<Long> targetIds = reviewRepository.findPurgeTargetIds(cutoff);
-      log.warn("[ReviewPurge] start cutoff={}", cutoff);
-      log.warn("[ReviewPurge] targetIds={}", targetIds);
+    log.warn("[ReviewPurge] start cutoff={}", cutoff);
+    log.warn("[ReviewPurge] targetIds={}", targetIds);
 
     if (targetIds.isEmpty()) {
       return;

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandService.java
@@ -6,4 +6,6 @@ import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 public interface ReviewCommandService {
 
   ReviewResDTO.WriteDTO createReview(Long orderId, ReviewReqDTO.WriteDTO dto, Long userId);
+
+  Void deleteReview(Long reviewId, Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandService.java
@@ -1,0 +1,9 @@
+package com.example.picknwhip_be.domain.review.service.command;
+
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+
+public interface ReviewCommandService {
+
+  ReviewResDTO.WriteDTO createReview(Long orderId, ReviewReqDTO.WriteDTO dto, Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,11 +57,15 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     // 리뷰 저장
     Review review = ReviewConverter.toReview(order, dto);
-    reviewRepository.save(review);
+    try {
+      reviewRepository.save(review);
+    } catch (DataIntegrityViolationException e) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+    }
 
     // 리뷰 이미지 저장
     if (dto.imageKeys() != null && !dto.imageKeys().isEmpty()) {
-      reviewImageKeyValidator.validateAll(dto.imageKeys(), userId);
+      reviewImageKeyValidator.validateAll(dto.imageKeys());
 
       List<ReviewImage> images = ReviewImageConverter.toReviewImages(review, dto.imageKeys());
       reviewImageRepository.saveAll(images);

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -13,11 +13,10 @@ import com.example.picknwhip_be.domain.review.entity.mapping.ReviewKeyword;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
 import com.example.picknwhip_be.domain.review.exception.ReviewException;
 import com.example.picknwhip_be.domain.review.exception.code.ReviewErrorCode;
-import com.example.picknwhip_be.domain.review.repository.ReviewImageRepository;
-import com.example.picknwhip_be.domain.review.repository.ReviewKeywordRepository;
-import com.example.picknwhip_be.domain.review.repository.ReviewRepository;
-import com.example.picknwhip_be.domain.review.repository.ReviewSelectedKeywordRepository;
+import com.example.picknwhip_be.domain.review.repository.*;
 import com.example.picknwhip_be.domain.review.validator.ReviewImageKeyValidator;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +34,9 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
   private final OrderRepository orderRepository;
   private final ReviewKeywordRepository reviewKeywordRepository;
   private final ReviewImageKeyValidator reviewImageKeyValidator;
+  private final ReviewReplyRepository reviewReplyRepository;
+  private final Clock clock;
+  private final ReviewLikeRepository reviewLikeRepository;
 
   @Override
   @Transactional
@@ -82,5 +84,34 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     reviewSelectedKeywordRepository.saveAll(mappings);
 
     return ReviewConverter.toWriteDTO(review.getId());
+  }
+
+  @Override
+  @Transactional
+  public Void deleteReview(Long reviewId, Long userId) {
+    Review review =
+        reviewRepository
+            .findById(reviewId)
+            .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+    if (!review.getUser().getUserId().equals(userId)) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_WRITE_NOT_ALLOWED);
+    }
+
+    if (review.isDeleted()) {
+      return null;
+    }
+
+    LocalDateTime now = LocalDateTime.now(clock);
+
+    review.softDelete(now);
+
+    reviewReplyRepository.softDeleteAllByReviewId(reviewId, now);
+    reviewImageRepository.softDeleteAllByReviewId(reviewId, now);
+
+    reviewSelectedKeywordRepository.deleteByReviewId(reviewId);
+    reviewLikeRepository.deleteByReviewId(reviewId);
+
+    return null;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -1,0 +1,86 @@
+package com.example.picknwhip_be.domain.review.service.command;
+
+import com.example.picknwhip_be.domain.order.entity.Order;
+import com.example.picknwhip_be.domain.order.repository.OrderRepository;
+import com.example.picknwhip_be.domain.review.converter.ReviewConverter;
+import com.example.picknwhip_be.domain.review.converter.ReviewImageConverter;
+import com.example.picknwhip_be.domain.review.converter.ReviewSelectedKeywordConverter;
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewKeyword;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
+import com.example.picknwhip_be.domain.review.exception.ReviewException;
+import com.example.picknwhip_be.domain.review.exception.code.ReviewErrorCode;
+import com.example.picknwhip_be.domain.review.repository.ReviewImageRepository;
+import com.example.picknwhip_be.domain.review.repository.ReviewKeywordRepository;
+import com.example.picknwhip_be.domain.review.repository.ReviewRepository;
+import com.example.picknwhip_be.domain.review.repository.ReviewSelectedKeywordRepository;
+import com.example.picknwhip_be.domain.review.validator.ReviewImageKeyValidator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewCommandServiceImpl implements ReviewCommandService {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewImageRepository reviewImageRepository;
+  private final ReviewSelectedKeywordRepository reviewSelectedKeywordRepository;
+  private final OrderRepository orderRepository;
+  private final ReviewKeywordRepository reviewKeywordRepository;
+  private final ReviewImageKeyValidator reviewImageKeyValidator;
+
+  @Override
+  @Transactional
+  public ReviewResDTO.WriteDTO createReview(Long orderId, ReviewReqDTO.WriteDTO dto, Long userId) {
+    Order order =
+        orderRepository
+            .findById(orderId)
+            .orElseThrow(() -> new ReviewException(ReviewErrorCode.ORDER_NOT_FOUND));
+
+    if (!order.getUser().getUserId().equals(userId)) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_WRITE_NOT_ALLOWED);
+    }
+
+    if (reviewRepository.existsByOrderId(orderId)) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+    }
+
+    // 리뷰 저장
+    Review review = ReviewConverter.toReview(order, dto);
+    reviewRepository.save(review);
+
+    // 리뷰 이미지 저장
+    if (dto.imageKeys() != null && !dto.imageKeys().isEmpty()) {
+      reviewImageKeyValidator.validateAll(dto.imageKeys(), userId);
+
+      List<ReviewImage> images = ReviewImageConverter.toReviewImages(review, dto.imageKeys());
+      reviewImageRepository.saveAll(images);
+    }
+
+    // 리뷰 키워드 저장
+    Set<String> unique = new HashSet<>(dto.keywords());
+    if (unique.size() != dto.keywords().size()) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_KEYWORD_DUPLICATED);
+    }
+
+    List<ReviewKeyword> keywords = reviewKeywordRepository.findAllByCodeIn(dto.keywords());
+
+    if (keywords.size() != dto.keywords().size()) {
+      throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_KEYWORD_CODE);
+    }
+
+    List<ReviewSelectedKeyword> mappings =
+        ReviewSelectedKeywordConverter.toSelectedKeywords(review, keywords);
+
+    reviewSelectedKeywordRepository.saveAll(mappings);
+
+    return ReviewConverter.toWriteDTO(review.getId());
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewPurgeService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewPurgeService.java
@@ -1,0 +1,26 @@
+package com.example.picknwhip_be.domain.review.service.command;
+
+import com.example.picknwhip_be.domain.review.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewPurgeService {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewReplyRepository reviewReplyRepository;
+  private final ReviewImageRepository reviewImageRepository;
+  private final ReviewSelectedKeywordRepository reviewSelectedKeywordRepository;
+  private final ReviewLikeRepository reviewLikeRepository;
+
+  @Transactional
+  public int hardDeleteReviewGraph(Long reviewId) {
+      reviewSelectedKeywordRepository.deleteByReviewId(reviewId);
+      reviewLikeRepository.deleteByReviewId(reviewId);
+      reviewImageRepository.hardDeleteAllByReviewId(reviewId);
+      reviewReplyRepository.hardDeleteAllByReviewId(reviewId);
+    return reviewRepository.hardDeleteById(reviewId);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewPurgeService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewPurgeService.java
@@ -17,10 +17,10 @@ public class ReviewPurgeService {
 
   @Transactional
   public int hardDeleteReviewGraph(Long reviewId) {
-      reviewSelectedKeywordRepository.deleteByReviewId(reviewId);
-      reviewLikeRepository.deleteByReviewId(reviewId);
-      reviewImageRepository.hardDeleteAllByReviewId(reviewId);
-      reviewReplyRepository.hardDeleteAllByReviewId(reviewId);
+    reviewSelectedKeywordRepository.deleteByReviewId(reviewId);
+    reviewLikeRepository.deleteByReviewId(reviewId);
+    reviewImageRepository.hardDeleteAllByReviewId(reviewId);
+    reviewReplyRepository.hardDeleteAllByReviewId(reviewId);
     return reviewRepository.hardDeleteById(reviewId);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/validator/ReviewImageKeyValidator.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/validator/ReviewImageKeyValidator.java
@@ -3,5 +3,5 @@ package com.example.picknwhip_be.domain.review.validator;
 import java.util.List;
 
 public interface ReviewImageKeyValidator {
-  void validateAll(List<String> imageKeys, Long userId);
+  void validateAll(List<String> imageKeys);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/validator/ReviewImageKeyValidator.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/validator/ReviewImageKeyValidator.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.review.validator;
+
+import java.util.List;
+
+public interface ReviewImageKeyValidator {
+  void validateAll(List<String> imageKeys, Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/global/infra/s3/S3ReviewImageKeyValidator.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/s3/S3ReviewImageKeyValidator.java
@@ -23,7 +23,7 @@ public class S3ReviewImageKeyValidator implements ReviewImageKeyValidator {
   private String bucket;
 
   @Override
-  public void validateAll(List<String> imageKeys, Long userId) {
+  public void validateAll(List<String> imageKeys) {
     validateBucketConfigured();
 
     for (String key : imageKeys) {

--- a/src/main/java/com/example/picknwhip_be/global/infra/s3/S3ReviewImageKeyValidator.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/s3/S3ReviewImageKeyValidator.java
@@ -1,0 +1,60 @@
+package com.example.picknwhip_be.global.infra.s3;
+
+import com.example.picknwhip_be.domain.review.exception.ReviewException;
+import com.example.picknwhip_be.domain.review.exception.code.ReviewErrorCode;
+import com.example.picknwhip_be.domain.review.validator.ReviewImageKeyValidator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Component
+@RequiredArgsConstructor
+public class S3ReviewImageKeyValidator implements ReviewImageKeyValidator {
+
+  private final S3Client s3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Override
+  public void validateAll(List<String> imageKeys, Long userId) {
+    validateBucketConfigured();
+
+    for (String key : imageKeys) {
+      validateKeyFormat(key);
+      validateObjectExists(key);
+    }
+  }
+
+  private void validateBucketConfigured() {
+    if (!StringUtils.hasText(bucket)) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_IMAGE_VALIDATION_FAILED);
+    }
+  }
+
+  private void validateKeyFormat(String key) {
+    if (!StringUtils.hasText(key)) {
+      throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_IMAGE_KEY);
+    }
+
+    if (!key.startsWith("review/")) {
+      throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_IMAGE_KEY);
+    }
+  }
+
+  private void validateObjectExists(String key) {
+    try {
+      s3Client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+    } catch (NoSuchKeyException e) {
+      throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_IMAGE_KEY);
+    } catch (S3Exception e) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_IMAGE_VALIDATION_FAILED);
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,3 +65,8 @@ cloud:
 
 kakao:
   admin-key: ${KAKAO_ADMIN_KEY}
+
+logging:
+  level:
+    root: INFO
+    com.example.picknwhip_be: INFO

--- a/src/main/resources/db/migration/V2__review_update.sql
+++ b/src/main/resources/db/migration/V2__review_update.sql
@@ -1,0 +1,38 @@
+ALTER TABLE review
+    ADD agreement BIT(1) NULL;
+
+ALTER TABLE review
+    ADD design_id BIGINT NULL;
+
+ALTER TABLE review
+    ADD order_id BIGINT NOT NULL;
+
+ALTER TABLE review
+    ADD shop_id BIGINT NOT NULL;
+
+ALTER TABLE review
+    ADD user_id BIGINT NOT NULL;
+
+ALTER TABLE review_keyword
+    ADD code VARCHAR(50) NOT NULL;
+
+ALTER TABLE review_keyword
+    ADD label VARCHAR(15) NOT NULL;
+
+ALTER TABLE review_keyword
+    ADD CONSTRAINT uc_review_keyword_code UNIQUE (code);
+
+ALTER TABLE review
+    ADD CONSTRAINT uc_review_order UNIQUE (order_id);
+
+ALTER TABLE review
+    ADD CONSTRAINT FK_REVIEW_ON_DESIGN FOREIGN KEY (design_id) REFERENCES design_gallery (id);
+
+ALTER TABLE review
+    ADD CONSTRAINT FK_REVIEW_ON_ORDER FOREIGN KEY (order_id) REFERENCES orders (id);
+
+ALTER TABLE review
+    ADD CONSTRAINT FK_REVIEW_ON_SHOP FOREIGN KEY (shop_id) REFERENCES shops (shop_id);
+
+ALTER TABLE review
+    ADD CONSTRAINT FK_REVIEW_ON_USER FOREIGN KEY (user_id) REFERENCES users (user_id);

--- a/src/main/resources/db/migration/V3__review_uncomment.sql
+++ b/src/main/resources/db/migration/V3__review_uncomment.sql
@@ -1,0 +1,37 @@
+ALTER TABLE review_reply
+    ADD seller_id BIGINT NULL;
+
+ALTER TABLE review_reply
+    ADD CONSTRAINT FK_REVIEW_REPLY_ON_SELLER FOREIGN KEY (seller_id) REFERENCES users (user_id);
+
+ALTER TABLE review_selected_keyword
+    ADD deleted_at datetime NULL;
+
+ALTER TABLE review_like
+    ADD user_id BIGINT NULL;
+
+ALTER TABLE review_like
+    MODIFY user_id BIGINT NOT NULL;
+
+ALTER TABLE review_like
+    ADD CONSTRAINT uk_review_like_review_user UNIQUE (review_id, user_id);
+
+ALTER TABLE review_like
+    ADD CONSTRAINT FK_REVIEW_LIKE_ON_USER FOREIGN KEY (user_id) REFERENCES users (user_id);
+
+ALTER TABLE design_gallery
+    ADD shop_id BIGINT NULL;
+
+ALTER TABLE design_gallery
+    MODIFY shop_id BIGINT NOT NULL;
+
+ALTER TABLE design_gallery
+    ADD CONSTRAINT FK_DESIGN_GALLERY_ON_SHOP FOREIGN KEY (shop_id) REFERENCES shops (shop_id);
+
+ALTER TABLE review_keyword
+    DROP COLUMN keyword;
+
+ALTER TABLE review_selected_keyword
+    DROP COLUMN deleted_at;
+
+ALTER TABLE review_keyword DROP INDEX uk_review_keyword_category_keyword;

--- a/src/main/resources/db/migration/V4__review_keyword.sql
+++ b/src/main/resources/db/migration/V4__review_keyword.sql
@@ -1,0 +1,41 @@
+-- review_keyword 테이블 seed 데이터
+INSERT INTO review_keyword (
+    category,
+    code,
+    label
+) VALUES
+      -- DESIGN_SATISFACTION
+      ('DESIGN_SATISFACTION', 'MATCH_REQUEST', '원하는 디자인을 잘해줬어요'),
+      ('DESIGN_SATISFACTION', 'PRETTY', '디자인이 예뻐요'),
+      ('DESIGN_SATISFACTION', 'CREATIVE', '창의적이에요'),
+      ('DESIGN_SATISFACTION', 'SPECIAL', '특별해요'),
+      ('DESIGN_SATISFACTION', 'LUXURIOUS', '화려한'),
+
+      -- SAME_AS_RESULT
+      ('SAME_AS_RESULT', 'SAME_AS_PHOTO', '사진과 똑같아요'),
+      ('SAME_AS_RESULT', 'BEYOND_EXPECTATION', '기대 이상이에요'),
+      ('SAME_AS_RESULT', 'ACCURATE', '정확해요'),
+      ('SAME_AS_RESULT', 'BETTER', '더 좋아요'),
+
+      -- TASTE
+      ('TASTE', 'DELICIOUS', '맛있어요'),
+      ('TASTE', 'FRESH', '신선해요'),
+      ('TASTE', 'SWEET', '달콤해요'),
+      ('TASTE', 'MOIST', '촉촉해요'),
+      ('TASTE', 'NOT_TOO_SWEET', '달지 않아요'),
+
+      -- COMMUNICATION
+      ('COMMUNICATION', 'KIND', '친절해요'),
+      ('COMMUNICATION', 'DETAILED', '상담이 자세해요'),
+      ('COMMUNICATION', 'FAST_RESPONSE', '응답이 빨라요'),
+      ('COMMUNICATION', 'GOOD_LISTENER', '요청사항을 잘 들어줘요'),
+      ('COMMUNICATION', 'EASY', '소통이 편해요'),
+
+      -- PICKUP
+      ('PICKUP', 'EASY_PICKUP', '픽업이 편해요'),
+      ('PICKUP', 'CLEAN', '매장이 깨끗해요'),
+      ('PICKUP', 'ON_TIME', '시간을 잘 지켜요')
+    AS new
+ON DUPLICATE KEY UPDATE
+                     category = new.category,
+                     label = new.label;

--- a/src/main/resources/db/seed/local/R__seed_local.sql
+++ b/src/main/resources/db/seed/local/R__seed_local.sql
@@ -1,12 +1,13 @@
 -- ======================================================
 -- Local Seed Data (Repeatable)
--- Applied only in 'local' profile
--- Safe to run multiple times
+-- Profile: local
+-- Goal   : Safe to run multiple times (idempotent)
 -- ======================================================
 
-/*
- * 1) Customer user (손님)
- */
+/* ------------------------------------------------------
+   1) Customer User (손님)
+   - Identified by UNIQUE(email) or UNIQUE(kakao_id)
+   ------------------------------------------------------ */
 INSERT INTO users (
     created_at,
     updated_at,
@@ -19,27 +20,28 @@ INSERT INTO users (
     phone,
     profile_image_url,
     status
-)
-VALUES (
-           NOW(6),
-           NOW(6),
-           NULL,
-           'local.customer@picknwhip.com',
-           2000000001,
-           '사용자',
-           '초코케이크',
-           NULL,
-           '010-1111-1111',
-           NULL,
-           'ACTIVE'
-       )
-    ON DUPLICATE KEY UPDATE
-                         updated_at = VALUES(updated_at),
-                         status = VALUES(status);
+) VALUES (
+             NOW(6),
+             NOW(6),
+             NULL,
+             'local.customer@picknwhip.com',
+             2000000001,
+             '사용자',
+             '초코케이크',
+             NULL,
+             '010-1111-1111',
+             NULL,
+             'ACTIVE'
+         ) AS new
+ON DUPLICATE KEY UPDATE
+                     updated_at = new.updated_at,
+                     status = new.status;
 
-/*
- * 2) Shop owner user (사장님) - shops.owner_id FK 때문에 필요
- */
+
+/* ------------------------------------------------------
+   2) Shop Owner User (사장님)
+   - Needed for shops.owner_id FK
+   ------------------------------------------------------ */
 INSERT INTO users (
     created_at,
     updated_at,
@@ -52,29 +54,29 @@ INSERT INTO users (
     phone,
     profile_image_url,
     status
-)
-VALUES (
-           NOW(6),
-           NOW(6),
-           NULL,
-           'local.owner@picknwhip.com',
-           1000000001,
-           '사장님',
-           '사장님',
-           NULL,
-           '010-0000-0000',
-           NULL,
-           'ACTIVE'
-       )
-    ON DUPLICATE KEY UPDATE
-                         updated_at = VALUES(updated_at),
-                         status = VALUES(status);
+) VALUES (
+             NOW(6),
+             NOW(6),
+             NULL,
+             'local.owner@picknwhip.com',
+             1000000001,
+             '사장님',
+             '사장님',
+             NULL,
+             '010-0000-0000',
+             NULL,
+             'ACTIVE'
+         ) AS new
+ON DUPLICATE KEY UPDATE
+                     updated_at = new.updated_at,
+                     status = new.status;
 
-/*
- * 3) Shop 1개 (owner는 위 local.owner)
- *  - location: POINT + SRID 4326 (MySQL GIS)
- *  - phone/shop_name/owner_id/location은 NOT NULL
- */
+
+/* ------------------------------------------------------
+   3) Shop (1개)
+   - owner_id: resolved by owner's email
+   - location: POINT + SRID 4326 (MySQL GIS)
+   ------------------------------------------------------ */
 INSERT INTO shops (
     shop_id,
     average_rating,
@@ -97,34 +99,33 @@ INSERT INTO shops (
     status,
     verification_status,
     owner_id
-)
-VALUES (
-           1,
-           NULL,
-           '테스트 케이크샵',
-           NULL,
-           NOW(6),
-           NULL,
-           '로컬 개발용 테스트 케이크샵입니다.',
-           ST_GeomFromText('POINT(45.0000 90.0000)', 4326),
-           NULL,
-           NULL,
-           NULL,
-           '02-1234-5678',
-           NULL,
-           NULL,
-           NULL,
-           NULL,
-           NULL,
-           '테스트 케이크샵',
-           'ACTIVE',
-           'VERIFIED',
-           (SELECT user_id FROM users WHERE email = 'local.owner@picknwhip.com')
-       )
-    ON DUPLICATE KEY UPDATE
-                         phone = VALUES(phone),
-                         shop_name = VALUES(shop_name),
-                         status = VALUES(status),
-                         verification_status = VALUES(verification_status),
-                         location = VALUES(location),
-                         owner_id = VALUES(owner_id);
+) VALUES (
+             1,
+             NULL,
+             '테스트 케이크샵',
+             NULL,
+             NOW(6),
+             NULL,
+             '로컬 개발용 테스트 케이크샵입니다.',
+             ST_GeomFromText('POINT(45.0000 90.0000)', 4326),
+             NULL,
+             NULL,
+             NULL,
+             '02-1234-5678',
+             NULL,
+             NULL,
+             NULL,
+             NULL,
+             NULL,
+             '테스트 케이크샵',
+             'ACTIVE',
+             'VERIFIED',
+             (SELECT user_id FROM users WHERE email = 'local.owner@picknwhip.com')
+         ) AS new
+ON DUPLICATE KEY UPDATE
+                     phone = new.phone,
+                     shop_name = new.shop_name,
+                     status = new.status,
+                     verification_status = new.verification_status,
+                     location = new.location,
+                     owner_id = new.owner_id;

--- a/src/main/resources/db/seed/local/R__seed_local_order.sql
+++ b/src/main/resources/db/seed/local/R__seed_local_order.sql
@@ -1,0 +1,108 @@
+-- shop_cake_sizes 테이블 seed 데이터
+INSERT INTO shop_cake_sizes (
+    size_id,
+    shop_id,
+    size_name,
+    diameter,
+    price
+) VALUES (
+             1,
+             1,
+             '1호',
+             '15cm',
+             30000
+         ) AS new
+ON DUPLICATE KEY UPDATE
+                     shop_id = new.shop_id,
+                     size_name = new.size_name,
+                     diameter = new.diameter,
+                     price = new.price;
+
+
+-- design_gallery 테이블 seed 데이터
+INSERT INTO design_gallery (
+    id,
+    shop_id,
+    design_name,
+    base_price,
+    image_url,
+    allergy_info,
+    description
+) VALUES (
+             1,
+             1,
+             '심플 플라워 디자인',
+             35000,
+             NULL,
+             '우유, 계란, 밀 함유',
+             '화이트 크림 베이스에 플라워 장식을 더한 심플한 디자인 케이크입니다.'
+         ) AS new
+ON DUPLICATE KEY UPDATE
+                     shop_id = new.shop_id,
+                     design_name = new.design_name,
+                     base_price = new.base_price,
+                     image_url = new.image_url,
+                     allergy_info = new.allergy_info,
+                     description = new.description;
+
+
+-- orders 테이블 seed 데이터
+INSERT INTO orders (
+    id,
+    user_id,
+    shop_id,
+    shop_cake_size_id,
+    design_id,
+    status,
+    pickup_datetime,
+    lettering_text,
+    lettering_line_count,
+    lettering_alignment,
+    additional_request,
+    reference_image_url,
+    payment_method,
+    payment_status,
+    total_price,
+    deposit_amount,
+    rejection_reason,
+    created_at,
+    updated_at
+) VALUES (
+             1,
+             1,
+             1,
+             1,
+             1,
+             'COMPLETED',
+             '2026-02-01 15:00:00',
+             '생일 축하해',
+             'ONE_LINE',
+             'CENTER',
+             '딸기 많이 올려주세요',
+             'https://example.com/reference/sample.jpg',
+             'CARD',
+             'PAID',
+             35000,
+             10000,
+             NULL,
+             NOW(),
+             NOW()
+         ) AS new
+ON DUPLICATE KEY UPDATE
+                     user_id = new.user_id,
+                     shop_id = new.shop_id,
+                     shop_cake_size_id = new.shop_cake_size_id,
+                     design_id = new.design_id,
+                     status = new.status,
+                     pickup_datetime = new.pickup_datetime,
+                     lettering_text = new.lettering_text,
+                     lettering_line_count = new.lettering_line_count,
+                     lettering_alignment = new.lettering_alignment,
+                     additional_request = new.additional_request,
+                     reference_image_url = new.reference_image_url,
+                     payment_method = new.payment_method,
+                     payment_status = new.payment_status,
+                     total_price = new.total_price,
+                     deposit_amount = new.deposit_amount,
+                     rejection_reason = new.rejection_reason,
+                     updated_at = NOW();


### PR DESCRIPTION
## 💡 Issue
- Close #80 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 하다 보니 생각보다 복잡하고 많은 걸 하게 되어 버려 죄송합니다 . . .
- flyway 추가 사항이 많으니 혹시 충돌 나면 DB 밀고 실행하면 좋을 것 같습니다
- 리뷰 이미지의 경우 프론트엔드에서 발급한 URL에 PUT을 해야 이미지 업로드가 가능하도록 제약을 빡빡하게 걸어 둬서 추후 싱크 맞추면서 수정 필요하면 수정할 예정입니다.
- 리뷰 이미지를 제외하고 리뷰 작성 및 삭제, 스케줄러를 통한 실제 데이터 삭제까지 테스트 완료했습니다.
- 리뷰 키워드가 많고 복잡하여 카테고리 내에 (code, label) 쌍으로 저장하였고, code를 요청 받아 조회 시 (code, label)로 보낼 생각입니다.
- 리뷰를 삭제할 시 soft delete로, 리뷰와 리뷰 이미지, 리뷰 답글이 deletedAt을 저장하도록 구현하였습니다. (리뷰 키워드와 도움이 됐어요는 중요 데이터가 아니라고 판단해 hard delete합니다.)
- hard delete를 위한 스케줄러는 매일 새벽 4시에 작동하도록 해두었고, 삭제한 지 30일이 지난 리뷰를 삭제하도록 구현하였습니다.
- 테스트를 위해서 seed 데이터를 하나의 플로우가 가능하도록 추가하였습니다.

## 🛠️ Changes
- Review 도메인 엔티티 및 외부 연관 엔티티들에 대해 필요한 Repository 파일들 생성
- Review 도메인의 엔티티 내 주석 처리되어 있던 컬럼들 주석 해제
- 기능 추가된 커스텀 옵션 동의 컬럼 추가
- ReviewKeyword에서 키워드를 영문 code 값과 label로 저장하도록 변경
- 변경 사항에 대해 flyway 마이그레이션 파일 생성
- review keyword 데이터 저장
- 테스트에 필요한 seed 데이터들 추가(order 관련해서 연관된 데이터 모두 하나씩 추가했습니다!)
- 리뷰 작성 및 삭제 API 구현을 위한 controller, dto, converter, exception, service 모두 작성
- soft delete 구현을 위한 자동 hard delete 스케줄러 구현

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?