### PR TITLE
[FEAT/#89] 작성한 리뷰 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,14 @@ dependencies {
 	implementation platform('io.jsonwebtoken:jjwt-bom:0.13.0')
 	implementation 'io.jsonwebtoken:jjwt-api'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
+
+    // QueryDSL : OpenFeign
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+    implementation "io.github.openfeign.querydsl:querydsl-core:7.0"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {
@@ -89,4 +96,23 @@ tasks.register("mysqlTest", Test) {
     useJUnitPlatform {
         includeTags "mysql"
     }
+}
+
+// QueryDSL 관련 설정
+// generated/querydsl 폴더 생성 & 삽입
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// 소스 세트에 생성 경로 추가 (구체적인 경로 지정)
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+// 컴파일 시 생성 경로 지정
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+// clean 태스크에 생성 폴더 삭제 로직 추가
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.example.picknwhip_be.domain.review.controller;
 import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.service.command.ReviewCommandService;
+import com.example.picknwhip_be.domain.review.service.query.ReviewQueryService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ReviewController {
   private final ReviewCommandService reviewCommandService;
+  private final ReviewQueryService reviewQueryService;
 
   @Operation(summary = "리뷰 작성 by 슝/하승연", description = "로그인한 회원이 리뷰를 등록하는 기능입니다.")
   @PostMapping("/{orderId}")
@@ -37,5 +41,21 @@ public class ReviewController {
 
     return ApiResponse.of(
         GeneralSuccessCode.OK, reviewCommandService.deleteReview(reviewId, userId));
+  }
+
+  @Operation(summary = "작성한 리뷰 목록 조회 by 슝/하승연", description = "회원이 작성한 리뷰 목록을 조회하는 기능입니다.")
+  @GetMapping("/me")
+  public ApiResponse<ReviewResDTO.MyReviewListDTO> GetMyReviewList(
+      @Parameter(description = "커서(마지막으로 조회한 reviewId). 첫 조회는 생략", example = "20")
+          @RequestParam(required = false)
+          Long cursor,
+      @Parameter(description = "조회 개수(기본 20, 최대 50)", example = "20")
+          @RequestParam(required = false, defaultValue = "20")
+          @Min(1)
+          @Max(50)
+          int size,
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewQueryService.GetMyReviewList(cursor, size, userId));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -26,7 +26,7 @@ public class ReviewController {
 
   @Operation(summary = "리뷰 작성 by 슝/하승연", description = "로그인한 회원이 리뷰를 등록하는 기능입니다.")
   @PostMapping("/{orderId}")
-  public ApiResponse<ReviewResDTO.WriteDTO> CreateReview(
+  public ApiResponse<ReviewResDTO.WriteDTO> createReview(
       @PathVariable Long orderId,
       @RequestBody @Valid ReviewReqDTO.WriteDTO dto,
       @Parameter(hidden = true) @ExtractPayload Long userId) {
@@ -36,7 +36,7 @@ public class ReviewController {
 
   @Operation(summary = "리뷰 삭제 by 슝/하승연", description = "회원이 작성한 리뷰를 삭제하는 기능입니다.")
   @DeleteMapping("/{reviewId}")
-  public ApiResponse<Void> DeleteReview(
+  public ApiResponse<Void> deleteReview(
       @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {
 
     return ApiResponse.of(
@@ -45,7 +45,7 @@ public class ReviewController {
 
   @Operation(summary = "작성한 리뷰 목록 조회 by 슝/하승연", description = "회원이 작성한 리뷰 목록을 조회하는 기능입니다.")
   @GetMapping("/me")
-  public ApiResponse<ReviewResDTO.MyReviewListDTO> GetMyReviewList(
+  public ApiResponse<ReviewResDTO.MyReviewListDTO> getMyReviewList(
       @Parameter(description = "커서(마지막으로 조회한 reviewId). 첫 조회는 생략", example = "20")
           @RequestParam(required = false)
           Long cursor,
@@ -56,6 +56,6 @@ public class ReviewController {
           int size,
       @Parameter(hidden = true) @ExtractPayload Long userId) {
     return ApiResponse.of(
-        GeneralSuccessCode.OK, reviewQueryService.GetMyReviewList(cursor, size, userId));
+        GeneralSuccessCode.OK, reviewQueryService.getMyReviewList(cursor, size, userId));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -42,7 +42,7 @@ public class ReviewConverter {
               .reviewId(row.reviewId())
               .rating(row.rating())
               .content(row.content())
-              .createdDate(row.CreatedAt())
+              .createdDate(row.createdAt())
               .reply(replyByReviewId.get(row.reviewId()))
               .imageUrls(imageUrlsByReviewId.getOrDefault(row.reviewId(), List.of()))
               .build();

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -1,9 +1,13 @@
 package com.example.picknwhip_be.domain.review.converter;
 
 import com.example.picknwhip_be.domain.order.entity.Order;
+import com.example.picknwhip_be.domain.review.dto.ReviewRow;
 import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.entity.Review;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class ReviewConverter {
   public static ReviewResDTO.WriteDTO toWriteDTO(Long reviewId) {
@@ -19,6 +23,44 @@ public class ReviewConverter {
         .rating(dto.rating())
         .content(dto.content())
         .agreement(dto.agreement())
+        .build();
+  }
+
+  public static ReviewResDTO.MyReviewListDTO toMyReviewListDTO(
+      long count,
+      double avgRating,
+      List<ReviewRow.MyReviewRow> pageRows,
+      Map<Long, List<String>> imageUrlsByReviewId,
+      Map<Long, String> replyByReviewId,
+      Long nextCursor,
+      boolean hasNext) {
+    List<ReviewResDTO.MyReviewItemDTO> items = new ArrayList<>(pageRows.size());
+
+    for (ReviewRow.MyReviewRow row : pageRows) {
+      ReviewResDTO.ReviewDTO content =
+          ReviewResDTO.ReviewDTO.builder()
+              .reviewId(row.reviewId())
+              .rating(row.rating())
+              .content(row.content())
+              .createdDate(row.CreatedAt())
+              .reply(replyByReviewId.get(row.reviewId()))
+              .imageUrls(imageUrlsByReviewId.getOrDefault(row.reviewId(), List.of()))
+              .build();
+
+      items.add(
+          ReviewResDTO.MyReviewItemDTO.builder()
+              .shopName(row.shopName())
+              .option(row.option())
+              .review(content)
+              .build());
+    }
+
+    return ReviewResDTO.MyReviewListDTO.builder()
+        .count(Math.toIntExact(count))
+        .rating(avgRating)
+        .items(items)
+        .nextCursor(nextCursor)
+        .hasNext(hasNext)
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
@@ -1,0 +1,33 @@
+package com.example.picknwhip_be.domain.review.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+
+// 작성한 리뷰 목록 조회 응답을 위한 중간 조회 전용 DTO 모음
+public class ReviewRow {
+  public record MyReviewRow(
+      Long reviewId,
+      String shopName,
+      String option,
+      int rating,
+      String content,
+      LocalDateTime CreatedAt) {
+    @QueryProjection
+    public MyReviewRow {}
+  }
+
+  public record MyReviewImageRow(Long reviewId, String s3Key, int sortOrder) {
+    @QueryProjection
+    public MyReviewImageRow {}
+  }
+
+  public record MyReviewReplyRow(Long reviewId, String replyContent) {
+    @QueryProjection
+    public MyReviewReplyRow {}
+  }
+
+  public record MyReviewSummaryRow(long count, Double averageRating) {
+    @QueryProjection
+    public MyReviewSummaryRow {}
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
@@ -11,7 +11,7 @@ public class ReviewRow {
       String option,
       int rating,
       String content,
-      LocalDateTime CreatedAt) {
+      LocalDateTime createdAt) {
     @QueryProjection
     public MyReviewRow {}
   }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -1,10 +1,42 @@
 package com.example.picknwhip_be.domain.review.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 
 public class ReviewResDTO {
   // 리뷰 작성 DTO
   @Builder
   public record WriteDTO(@Schema(description = "생성된 리뷰 ID", example = "1") Long reviewId) {}
+
+  // 리뷰 DTO 코어
+  @Builder
+  public record ReviewDTO(
+      @Schema(description = "리뷰 ID", example = "1") Long reviewId,
+      @Schema(description = "별점", example = "5") int rating,
+      @Schema(description = "리뷰 내용", example = "너무 예쁘고 맛있어요!") String content,
+      @Schema(description = "사장님 답글", example = "감사합니다.") String reply,
+      @Schema(description = "리뷰 이미지 url 목록", example = "[\"https://....jpg\"]")
+          List<String> imageUrls,
+      @Schema(description = "작성일", example = "2026-01-01")
+          @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+          LocalDateTime createdDate) {}
+
+  // 작성한 리뷰
+  @Builder
+  public record MyReviewItemDTO(
+      @Schema(description = "가게명", example = "달콤한 순간") String shopName,
+      @Schema(description = "케이크 옵션", example = "기념일 케이크") String option,
+      @Schema(description = "리뷰 내용") ReviewDTO review) {}
+
+  // 작성한 리뷰 목록 조회 DTO
+  @Builder
+  public record MyReviewListDTO(
+      @Schema(description = "작성한 리뷰 개수", example = "1") int count,
+      @Schema(description = "평균 별점", example = "5.0") double rating,
+      @Schema(description = "리뷰 목록") List<MyReviewItemDTO> items,
+      @Schema(description = "다음 커서 값", example = "0") Long nextCursor,
+      @Schema(description = "다음 데이터 존재", example = "true") boolean hasNext) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
   boolean existsByOrderId(Long orderId);
 
   @Query(

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.review.dto.ReviewRow;
+import java.util.List;
+
+public interface ReviewRepositoryCustom {
+  ReviewRow.MyReviewSummaryRow fetchMyReviewSummary(Long userId);
+
+  List<ReviewRow.MyReviewRow> fetchMyReviews(Long userId, Long cursor, int limit);
+
+  List<ReviewRow.MyReviewImageRow> fetchMyReviewImages(List<Long> reviewIds);
+
+  List<ReviewRow.MyReviewReplyRow> fetchMyReviewReplies(List<Long> reviewIds);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.example.picknwhip_be.domain.review.repository;
+
+import com.example.picknwhip_be.domain.order.entity.QOrder;
+import com.example.picknwhip_be.domain.review.dto.*;
+import com.example.picknwhip_be.domain.review.entity.QReview;
+import com.example.picknwhip_be.domain.review.entity.mapping.QReviewImage;
+import com.example.picknwhip_be.domain.review.entity.mapping.QReviewReply;
+import com.example.picknwhip_be.domain.shop.entity.QShop;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  private static final QReview review = QReview.review;
+  private static final QOrder order = QOrder.order;
+  private static final QShop shop = QShop.shop;
+  private static final QReviewImage reviewImage = QReviewImage.reviewImage;
+  private static final QReviewReply reviewReply = QReviewReply.reviewReply;
+
+  @Override
+  public ReviewRow.MyReviewSummaryRow fetchMyReviewSummary(Long userId) {
+    return queryFactory
+        .select(new QReviewRow_MyReviewSummaryRow(review.id.count(), review.rating.avg()))
+        .from(review)
+        .where(review.user.userId.eq(userId), review.deletedAt.isNull())
+        .fetchOne();
+  }
+
+  @Override
+  public List<ReviewRow.MyReviewRow> fetchMyReviews(Long userId, Long cursor, int limit) {
+    return queryFactory
+        .select(
+            new QReviewRow_MyReviewRow(
+                review.id,
+                shop.shopName,
+                order.designGallery.designName,
+                review.rating,
+                review.content,
+                review.createdAt))
+        .from(review)
+        .join(review.order, order)
+        .join(order.shop, shop)
+        .where(
+            review.user.userId.eq(userId),
+            cursor != null ? review.id.lt(cursor) : null,
+            review.deletedAt.isNull())
+        .orderBy(review.id.desc())
+        .limit(limit)
+        .fetch();
+  }
+
+  @Override
+  public List<ReviewRow.MyReviewImageRow> fetchMyReviewImages(List<Long> reviewIds) {
+    if (reviewIds == null || reviewIds.isEmpty()) {
+      return List.of();
+    }
+
+    return queryFactory
+        .select(
+            new QReviewRow_MyReviewImageRow(
+                reviewImage.review.id, reviewImage.s3Key, reviewImage.sortOrder))
+        .from(reviewImage)
+        .where(reviewImage.review.id.in(reviewIds), reviewImage.deletedAt.isNull())
+        .orderBy(reviewImage.review.id.asc(), reviewImage.sortOrder.asc())
+        .fetch();
+  }
+
+  @Override
+  public List<ReviewRow.MyReviewReplyRow> fetchMyReviewReplies(List<Long> reviewIds) {
+    if (reviewIds == null || reviewIds.isEmpty()) {
+      return List.of();
+    }
+
+    return queryFactory
+        .select(new QReviewRow_MyReviewReplyRow(reviewReply.review.id, reviewReply.content))
+        .from(reviewReply)
+        .where(reviewReply.review.id.in(reviewIds), reviewReply.deletedAt.isNull())
+        .fetch();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.review.service.query;
+
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+
+public interface ReviewQueryService {
+  ReviewResDTO.MyReviewListDTO GetMyReviewList(Long cursor, int size, Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
@@ -3,5 +3,5 @@ package com.example.picknwhip_be.domain.review.service.query;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 
 public interface ReviewQueryService {
-  ReviewResDTO.MyReviewListDTO GetMyReviewList(Long cursor, int size, Long userId);
+  ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -19,7 +19,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
   private final S3Service s3Service;
 
   @Override
-  public ReviewResDTO.MyReviewListDTO GetMyReviewList(Long cursor, int size, Long userId) {
+  public ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId) {
     ReviewRow.MyReviewSummaryRow summary = reviewRepository.fetchMyReviewSummary(userId);
     long count = (summary == null) ? 0L : summary.count();
     double avgRating = roundTo1Decimal(summary == null ? null : summary.averageRating());

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -1,0 +1,77 @@
+package com.example.picknwhip_be.domain.review.service.query;
+
+import com.example.picknwhip_be.domain.S3.service.S3Service;
+import com.example.picknwhip_be.domain.review.converter.ReviewConverter;
+import com.example.picknwhip_be.domain.review.dto.ReviewRow;
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+import com.example.picknwhip_be.domain.review.repository.ReviewRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryServiceImpl implements ReviewQueryService {
+  private final ReviewRepository reviewRepository;
+  private final S3Service s3Service;
+
+  @Override
+  public ReviewResDTO.MyReviewListDTO GetMyReviewList(Long cursor, int size, Long userId) {
+    ReviewRow.MyReviewSummaryRow summary = reviewRepository.fetchMyReviewSummary(userId);
+    long count = (summary == null) ? 0L : summary.count();
+    double avgRating = roundTo1Decimal(summary == null ? null : summary.averageRating());
+
+    int limit = size + 1;
+    List<ReviewRow.MyReviewRow> rows = reviewRepository.fetchMyReviews(userId, cursor, limit);
+
+    boolean hasNext = rows.size() > size;
+    List<ReviewRow.MyReviewRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+
+    Long nextCursor = null;
+    if (hasNext && !pageRows.isEmpty()) {
+      nextCursor = pageRows.get(pageRows.size() - 1).reviewId();
+    }
+
+    List<Long> reviewIds = pageRows.stream().map(ReviewRow.MyReviewRow::reviewId).toList();
+
+    List<ReviewRow.MyReviewImageRow> imageRows = reviewRepository.fetchMyReviewImages(reviewIds);
+    Map<Long, List<String>> imageUrlsByReviewId = groupImageUrlsByReviewId(imageRows);
+
+    List<ReviewRow.MyReviewReplyRow> replyRows = reviewRepository.fetchMyReviewReplies(reviewIds);
+    Map<Long, String> replyByReviewId = groupReplyByReviewId(replyRows);
+
+    return ReviewConverter.toMyReviewListDTO(
+        count, avgRating, pageRows, imageUrlsByReviewId, replyByReviewId, nextCursor, hasNext);
+  }
+
+  private Map<Long, String> groupReplyByReviewId(List<ReviewRow.MyReviewReplyRow> replyRows) {
+    Map<Long, String> map = new LinkedHashMap<>();
+    for (ReviewRow.MyReviewReplyRow row : replyRows) {
+      map.putIfAbsent(row.reviewId(), row.replyContent());
+    }
+    return map;
+  }
+
+  private Map<Long, List<String>> groupImageUrlsByReviewId(
+      List<ReviewRow.MyReviewImageRow> imageRows) {
+    Map<Long, List<String>> map = new LinkedHashMap<>();
+    for (ReviewRow.MyReviewImageRow row : imageRows) {
+      map.computeIfAbsent(row.reviewId(), k -> new ArrayList<>());
+      List<String> urls = map.get(row.reviewId());
+      if (urls.size() >= 5) {
+        continue;
+      }
+      String url = s3Service.createPresignedDownloadUrl(row.s3Key());
+      urls.add(url);
+    }
+    return map;
+  }
+
+  private double roundTo1Decimal(Double avg) {
+    double value = (avg == null) ? 0.0 : avg;
+    return Math.round(value * 10.0) / 10.0;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/global/config/QuerydslConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/config/QuerydslConfig.java
@@ -8,8 +8,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class QuerydslConfig {
 
-    @Bean
-    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
-        return new JPAQueryFactory(entityManager);
-    }
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/global/config/QuerydslConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.example.picknwhip_be.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/global/config/S3Config.java
+++ b/src/main/java/com/example/picknwhip_be/global/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.example.picknwhip_be.config;
+package com.example.picknwhip_be.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/example/picknwhip_be/global/config/TimeConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/config/TimeConfig.java
@@ -1,4 +1,4 @@
-package com.example.picknwhip_be.config;
+package com.example.picknwhip_be.global.config;
 
 import java.time.Clock;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
## 💡 Issue
- Close #89

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- GET /api/reviews/me 구현했습니당
- 그냥 JQPL로 구현할까 하다가 나중에 필터링이 생길 수 있다는 확장 가능성을 생각해서 QueryDSL 세팅하고 사용했습니다.
- JPAQueryFactory는 EntityManager로 매번 생성하지 않도록 Config 파일에 빈으로 등록해서 재사용할 수 있게 했습니다.
- 요구사항이 여러 테이블에서 필요한 데이터를 조회 후 하나로 엮게끔 되어 있어서, 로직이 복잡하고 엔티티에서 조회 결과뿐만 아니라 불필요한 컬럼까지 로딩하기 싫어서 조회 전용 DTO로 Row를 만들어 책임을 분리하고 가공하기 쉽도록 했습니다.
- 각 Row에 @QueryProjection을 적하여 타입 안정성을 높였습니다.
- 리뷰 이미지는 s3Service에 미리 만들어둔 이미지 키 값으로 조회 전용 url을 반환해주는 메소드를 사용해 url을 응답하도록 했습니다.
- DTO는 처음에는 단일 구조로 설계하는데, 추후 가게 리뷰 목록 조회나 리뷰 상세 조회 때 리뷰 데이터를 담는 DTO를 재사용하기 위해서 공통 DTO와 해당 API를 위한 DTO로 확장하는 구조로 변경했습니다.
- 테스트하다 보니 리뷰 작성 API에서 soft delete한 리뷰를 재작성하면 orderId에 대해 유니크 충돌이 나는 걸 발견해서 이 문제는 따로 이슈를 팠습니다...

## 🛠️ Changes
- Config 폴더를 global 아래로 이동 및 Querydsl 세팅
- Querydsl 의존성 추가 및 config 파일 작성
- 최종 응답 DTO 및 DB 조회를 위한 중간 DTO인 Row 레코드 작성
- 컨트롤러에서 GetMyReviewList 작성
- 커스텀 레포지토리 및 구현체 파일 생성하여 Querydsl 활용한 조회 쿼리 작성
- QueryService 인터페이스 및 구현체 파일 작성
- reviewId 기준 커서 기반 페이징으로 무한 스크롤 구현
- 컨버터에서 최종 응답 DTO로 조립

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?