### PR TITLE
[FIX/#90] 리뷰 소프트 삭제 후 동일 주문에 리뷰 재작성 불가 문제

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-  boolean existsByOrderId(Long orderId);
+  boolean existsByOrderIdAndDeletedAtIsNull(Long orderId);
 
   @Query(
       value =

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -51,7 +51,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
       throw new ReviewException(ReviewErrorCode.REVIEW_WRITE_NOT_ALLOWED);
     }
 
-    if (reviewRepository.existsByOrderId(orderId)) {
+    if (reviewRepository.existsByOrderIdAndDeletedAtIsNull(orderId)) {
       throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
     }
 

--- a/src/main/resources/db/migration/V5__review_update_unique.sql
+++ b/src/main/resources/db/migration/V5__review_update_unique.sql
@@ -1,0 +1,14 @@
+-- 1) FK가 사용할 일반 인덱스 먼저 추가
+CREATE INDEX idx_review_order_id ON review (order_id);
+
+-- 2) 기존 유니크 인덱스 드롭
+ALTER TABLE review DROP INDEX uc_review_order;
+
+-- 3) 삭제되지 않은 리뷰에만 order_id가 살아있는 generated column 추가
+ALTER TABLE review
+    ADD COLUMN active_order_id BIGINT
+        AS (CASE WHEN deleted_at IS NULL THEN order_id ELSE NULL END) STORED;
+
+-- 4) 활성 리뷰에 대해서만 유니크 강제
+ALTER TABLE review
+    ADD UNIQUE KEY uc_review_active_order (active_order_id);


### PR DESCRIPTION
## 💡 Issue
- Close #90 

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [x] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- API 테스트 과정에서 리뷰를 소프트 삭제한 뒤 동일 주문에 대해 리뷰를 다시 작성하려고 하면, 기존 리뷰가 DB에 남아 있어 주문별 리뷰 유니크 제약 조건에 의해 중복 오류가 발생하는 이슈를 발견했습니다.
- 기존에 한 order에는 하나의 review가 존재해야 한다는 유니크 제약을 걸어뒀었는데, soft delete를 구현했다 보니 아직 데이터가 남아있어 충돌이 나는 것이었습니다.
- flyway 마이그레이션 파일을 만들어 해당 유니크 인덱스를 드롭하고 active_order_id 컬럼을 추가해 삭제되지 않은 리뷰에 대해서만 유니크가 강제되도록 수정하였습니다.
- 이미 DB가 있는 상태로 수정하다 보니 FK에 대한 인덱스가 필수이다 보니 삭제부터 할 수 없어 일반 인덱스를 추가해주고 수정하였습니다.
- 사용 중인 쿼리문에도 조건을 추가하여 절대(!) 문제가 생기지 않도록 예방 조치했습니다.

## 🛠️ Changes
- 기존 review_order 유니크 삭제 후 active_order_id 칼럼 추가하여 review_active_order 유니크 생성
- 쿼리문에도 2차 방지를 위해 조건 추가


## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?