### PR TITLE
[FEAT/#101] 전체가게, 마이픽 가게 위치 조회

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
@@ -26,4 +26,7 @@ public interface FavoriteShopRepository extends JpaRepository<FavoriteShop, Long
           + "ORDER BY fs.id DESC")
   List<FavoriteShop> findAllByUserIdAndCursor(
       @Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
+
+  @Query("SELECT f.shop.id FROM FavoriteShop f WHERE f.user.userId = :userId")
+  List<Long> findShopIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/favorite/repository/FavoriteShopRepository.java
@@ -5,6 +5,7 @@ import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,6 +28,6 @@ public interface FavoriteShopRepository extends JpaRepository<FavoriteShop, Long
   List<FavoriteShop> findAllByUserIdAndCursor(
       @Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 
-  @Query("SELECT f.shop.id FROM FavoriteShop f WHERE f.user.userId = :userId")
-  List<Long> findShopIdsByUserId(@Param("userId") Long userId);
+  @Query("SELECT distinct f.shop.id FROM FavoriteShop f WHERE f.user.userId = :userId")
+  Set<Long> findShopIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -2,9 +2,13 @@ package com.example.picknwhip_be.domain.shop.controller;
 
 import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
 import com.example.picknwhip_be.domain.shop.dto.res.ShopPreviewResponseDto;
+import com.example.picknwhip_be.domain.shop.service.ShopQueryService;
 import com.example.picknwhip_be.domain.shop.service.ShopService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class ShopController {
 
   private final ShopService shopService;
+  private final ShopQueryService shopQueryService;
 
   @Operation(
       summary = "내 주변 가게 조회",
@@ -30,12 +35,19 @@ public class ShopController {
     return ResponseEntity.ok(shopService.getNearbyShops(lat, lon, radius));
   }
 
+  @Operation(
+      summary = "뷰포트 내 가게 조회",
+      description = "현재 뷰포트 내 가게들 정보를 보여줍니다. isPicked로 마이픽에 있는 가게인지 알 수 있습니다.")
+  @GetMapping("/maps")
   public ApiResponse<ShopResDTO.ShopInMapListDTO> getShopOnMapList(
-      @RequestParam Double lowLat,
-      @RequestParam Double highLat,
-      @RequestParam Double lowLon,
-      @RequestParam Double highLon) {
+      @Parameter(description = "최소 위도 = 하단") @RequestParam Double lowLat,
+      @Parameter(description = "최대 위도 = 상단") @RequestParam Double highLat,
+      @Parameter(description = "최소 경도 = 좌측") @RequestParam Double lowLon,
+      @Parameter(description = "최대 경도 = 우측") @RequestParam Double highLon,
+      @ExtractPayload Long userId) {
 
-    return null;
+    ShopResDTO.ShopInMapListDTO result =
+        shopQueryService.findShopInMap(lowLat, highLat, lowLon, highLon, userId);
+    return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -1,7 +1,9 @@
 package com.example.picknwhip_be.domain.shop.controller;
 
+import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
 import com.example.picknwhip_be.domain.shop.dto.res.ShopPreviewResponseDto;
 import com.example.picknwhip_be.domain.shop.service.ShopService;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -26,5 +28,14 @@ public class ShopController {
       @RequestParam double lon,
       @RequestParam(defaultValue = "1000") double radius) {
     return ResponseEntity.ok(shopService.getNearbyShops(lat, lon, radius));
+  }
+
+  public ApiResponse<ShopResDTO.ShopInMapListDTO> getShopOnMapList(
+      @RequestParam Double lowLat,
+      @RequestParam Double highLat,
+      @RequestParam Double lowLon,
+      @RequestParam Double highLon) {
+
+    return null;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -48,7 +49,7 @@ public class ShopConverter {
         .build();
   }
 
-  public ShopResDTO.ShopInMapListDTO toShopInMapListDTO(List<Shop> shop) {
+  public ShopResDTO.ShopInMapListDTO toShopInMapListDTO(List<Shop> shop, Set<Long> pickedShopIds) {
     return ShopResDTO.ShopInMapListDTO.builder()
         .shops(
             shop.stream()
@@ -57,8 +58,9 @@ public class ShopConverter {
                         ShopResDTO.ShopInMap.builder()
                             .shopId(item.getId())
                             .shopName(item.getShopName())
-                            .latitude(item.getLocation().getX())
-                            .longitude(item.getLocation().getY())
+                            .latitude(item.getLocation().getY())
+                            .longitude(item.getLocation().getX())
+                            .isPicked(pickedShopIds.contains(item.getId()))
                             .build())
                 .toList())
         .build();

--- a/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
@@ -1,6 +1,8 @@
 package com.example.picknwhip_be.domain.shop.converter;
 
+import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
 import com.example.picknwhip_be.domain.shop.dto.res.ShopPreviewResponseDto;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,6 +45,22 @@ public class ShopConverter {
         .minPrice(info.getMinPrice())
         .distance(info.getDistance())
         .tags(tagList)
+        .build();
+  }
+
+  public ShopResDTO.ShopInMapListDTO toShopInMapListDTO(List<Shop> shop) {
+    return ShopResDTO.ShopInMapListDTO.builder()
+        .shops(
+            shop.stream()
+                .map(
+                    item ->
+                        ShopResDTO.ShopInMap.builder()
+                            .shopId(item.getId())
+                            .shopName(item.getShopName())
+                            .latitude(item.getLocation().getX())
+                            .longitude(item.getLocation().getY())
+                            .build())
+                .toList())
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/dto/ShopResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/dto/ShopResDTO.java
@@ -1,0 +1,30 @@
+package com.example.picknwhip_be.domain.shop.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShopResDTO {
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ShopInMapListDTO {
+    private List<ShopInMap> shops;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ShopInMap {
+    private Long shopId;
+    private String shopName;
+    private Double latitude;
+    private Double longitude;
+    private boolean isPicked;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/shop/dto/ShopResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/dto/ShopResDTO.java
@@ -1,5 +1,6 @@
 package com.example.picknwhip_be.domain.shop.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,6 +26,8 @@ public class ShopResDTO {
     private String shopName;
     private Double latitude;
     private Double longitude;
+
+    @JsonProperty("isPicked")
     private boolean isPicked;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
@@ -76,7 +76,9 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
   @Query(
       value =
           "SELECT * FROM shops s "
-              + "WHERE MBRContains(ST_SRID(ST_MakeEnvelope(POINT(:lowLon, :lowLat), POINT(:highLon, :highLat)), 4326), s.location)",
+              + "WHERE s.status = 'ACTIVE' "
+              + "AND ST_SRID(s.location) = 4326 "
+              + "AND MBRContains(ST_SRID(ST_MakeEnvelope(POINT(:lowLon, :lowLat), POINT(:highLon, :highLat)), 4326), s.location)",
       nativeQuery = true)
   List<Shop> findShopsInBoundary(
       @Param("lowLat") Double lowLat,

--- a/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
@@ -75,8 +75,8 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
 
   @Query(
       value =
-          "SELECT * FROM shop s "
-              + "WHERE MBRContains(ST_MakeEnvelope(:lowLon, :lowLat, :highLon, :highLat, 4326), s.location)",
+          "SELECT * FROM shops s "
+              + "WHERE MBRContains(ST_SRID(ST_MakeEnvelope(POINT(:lowLon, :lowLat), POINT(:highLon, :highLat)), 4326), s.location)",
       nativeQuery = true)
   List<Shop> findShopsInBoundary(
       @Param("lowLat") Double lowLat,

--- a/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
@@ -72,4 +72,15 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
       @Param("maxLon") double maxLon,
       @Param("radius") double radius,
       @Param("limit") int limit);
+
+  @Query(
+      value =
+          "SELECT * FROM shop s "
+              + "WHERE MBRContains(ST_MakeEnvelope(:lowLon, :lowLat, :highLon, :highLat, 4326), s.location)",
+      nativeQuery = true)
+  List<Shop> findShopsInBoundary(
+      @Param("lowLat") Double lowLat,
+      @Param("highLat") Double highLat,
+      @Param("lowLon") Double lowLon,
+      @Param("highLon") Double highLon);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/service/ShopQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/service/ShopQueryService.java
@@ -5,7 +5,6 @@ import com.example.picknwhip_be.domain.shop.converter.ShopConverter;
 import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +25,10 @@ public class ShopQueryService {
 
     List<Shop> shops = shopRepository.findShopsInBoundary(lowLat, highLat, lowLon, highLon);
 
-    Set<Long> pickedShopIds = new HashSet<>();
-    if (userId != null) {
-      List<Long> ids = favoriteShopRepository.findShopIdsByUserId(userId);
-      pickedShopIds.addAll(ids);
-    }
+    Set<Long> pickedShopIds =
+        (userId != null)
+            ? favoriteShopRepository.findShopIdsByUserId(userId)
+            : java.util.Collections.emptySet();
 
     return shopConverter.toShopInMapListDTO(shops, pickedShopIds);
   }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/service/ShopQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/service/ShopQueryService.java
@@ -1,0 +1,25 @@
+package com.example.picknwhip_be.domain.shop.service;
+
+import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
+import com.example.picknwhip_be.domain.shop.entity.Shop;
+import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShopQueryService {
+
+  private final ShopRepository shopRepository;
+
+  public ShopResDTO.ShopInMapListDTO findShopInMap(
+      Double lowLat, Double highLat, Double lowLon, Double highLon) {
+
+    List<Shop> shop = shopRepository.findShopsInBoundary(lowLat, highLat, lowLon, highLon);
+
+    return null;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/shop/service/ShopQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/service/ShopQueryService.java
@@ -1,9 +1,13 @@
 package com.example.picknwhip_be.domain.shop.service;
 
+import com.example.picknwhip_be.domain.favorite.repository.FavoriteShopRepository;
+import com.example.picknwhip_be.domain.shop.converter.ShopConverter;
 import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +18,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShopQueryService {
 
   private final ShopRepository shopRepository;
+  private final FavoriteShopRepository favoriteShopRepository;
+  private final ShopConverter shopConverter;
 
   public ShopResDTO.ShopInMapListDTO findShopInMap(
-      Double lowLat, Double highLat, Double lowLon, Double highLon) {
+      Double lowLat, Double highLat, Double lowLon, Double highLon, Long userId) {
 
-    List<Shop> shop = shopRepository.findShopsInBoundary(lowLat, highLat, lowLon, highLon);
+    List<Shop> shops = shopRepository.findShopsInBoundary(lowLat, highLat, lowLon, highLon);
 
-    return null;
+    Set<Long> pickedShopIds = new HashSet<>();
+    if (userId != null) {
+      List<Long> ids = favoriteShopRepository.findShopIdsByUserId(userId);
+      pickedShopIds.addAll(ids);
+    }
+
+    return shopConverter.toShopInMapListDTO(shops, pickedShopIds);
   }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #101 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 뷰표트 내 가게 위치 조회 API 입니다
- 화면 상단, 하단, 좌측, 우측 좌표 입력받고 직사각형 내 위치한 가게 정보 리턴합니다.
- is_picked로 찜 여부 알 수 있습니다.
- is_picked는 join으로 처리하지 않고 사용자가 픽한 가게와 뷰포트 내 가게를 각각 조회 후 교집합으로 처리했습니다.

## 🛠️ Changes
- [ ] 가게 위치 조회 API


## 📸 Screenshots
<img width="784" height="324" alt="image" src="https://github.com/user-attachments/assets/3b105b2f-f0af-4051-9f48-e4905098c985" />

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?