### PR TITLE
[FEAT/#94] 리뷰 상세 조회 및 도움/취소 API 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -83,9 +83,7 @@ public class ReviewController {
 
   @Operation(summary = "리뷰 상세 조회 by 슝/하승연", description = "특정 리뷰의 정보를 상세 조회하는 기능입니다.")
   @GetMapping("/{reviewId}")
-  public ApiResponse<ReviewResDTO.ReviewDetailDTO> getReviewDetail(
-      @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {
-    return ApiResponse.of(
-        GeneralSuccessCode.OK, reviewQueryService.getReviewDetail(reviewId, userId));
+  public ApiResponse<ReviewResDTO.ReviewDetailDTO> getReviewDetail(@PathVariable Long reviewId) {
+    return ApiResponse.of(GeneralSuccessCode.OK, reviewQueryService.getReviewDetail(reviewId));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -64,4 +64,29 @@ public class ReviewController {
   public ApiResponse<ReviewResDTO.BestReviewListDTO> getBestReviews() {
     return ApiResponse.of(GeneralSuccessCode.OK, reviewQueryService.getBestCustomReviews());
   }
+
+  @Operation(summary = "리뷰 도움 선택 by 슝/하승연", description = "리뷰에 ‘도움이 됐어요’를 선택하는 기능입니다.")
+  @PutMapping("/{reviewId}/likes")
+  public ApiResponse<ReviewResDTO.ReviewLikeDTO> updateReviewLike(
+      @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewCommandService.saveReviewLike(reviewId, userId));
+  }
+
+  @Operation(summary = "리뷰 도움 취소 by 슝/하승연", description = "리뷰에 ‘도움이 됐어요’를 취소하는 기능입니다.")
+  @DeleteMapping("/{reviewId}/likes")
+  public ApiResponse<ReviewResDTO.ReviewLikeDTO> deleteReviewLike(
+      @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewCommandService.deleteReviewLike(reviewId, userId));
+  }
+
+  //    @Operation(summary = "리뷰 상세 조회 by 슝/하승연", description = "특정 리뷰의 정보를 상세 조회하는 기능입니다.")
+  //    @GetMapping("/{reviewId}")
+  //    public ApiResponse<ReviewResDTO.ReviewLikeDTO> getReviewDetail(
+  //            @PathVariable Long reviewId,
+  //            @Parameter(hidden = true) @ExtractPayload Long userId
+  //    ){
+  //        return ApiResponse.of(GeneralSuccessCode.CREATED, (reviewId, userId));
+  //    }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -81,12 +81,11 @@ public class ReviewController {
         GeneralSuccessCode.OK, reviewCommandService.deleteReviewLike(reviewId, userId));
   }
 
-  //    @Operation(summary = "리뷰 상세 조회 by 슝/하승연", description = "특정 리뷰의 정보를 상세 조회하는 기능입니다.")
-  //    @GetMapping("/{reviewId}")
-  //    public ApiResponse<ReviewResDTO.ReviewLikeDTO> getReviewDetail(
-  //            @PathVariable Long reviewId,
-  //            @Parameter(hidden = true) @ExtractPayload Long userId
-  //    ){
-  //        return ApiResponse.of(GeneralSuccessCode.CREATED, (reviewId, userId));
-  //    }
+  @Operation(summary = "리뷰 상세 조회 by 슝/하승연", description = "특정 리뷰의 정보를 상세 조회하는 기능입니다.")
+  @GetMapping("/{reviewId}")
+  public ApiResponse<ReviewResDTO.ReviewDetailDTO> getReviewDetail(
+      @PathVariable Long reviewId, @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewQueryService.getReviewDetail(reviewId, userId));
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -7,6 +7,7 @@ import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
 import com.example.picknwhip_be.domain.user.entity.User;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,29 @@ public class ReviewConverter {
         .reviewId(reviewId)
         .isLike(isLike)
         .likeCount(likeCount)
+        .build();
+  }
+
+  public static ReviewResDTO.ReviewDetailDTO toReviewDetailDTO(
+      Long reviewId,
+      int rating,
+      String content,
+      String reply,
+      List<String> imageUrls,
+      LocalDateTime createdDate,
+      String nickname,
+      String profileUrl,
+      List<ReviewResDTO.KeywordDTO> keywords) {
+    return ReviewResDTO.ReviewDetailDTO.builder()
+        .reviewId(reviewId)
+        .nickname(nickname)
+        .profileUrl(profileUrl)
+        .rating(rating)
+        .content(content)
+        .imageUrls(imageUrls)
+        .keywords(keywords)
+        .createdDate(createdDate)
+        .reply(reply)
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -5,6 +5,8 @@ import com.example.picknwhip_be.domain.review.dto.ReviewRow;
 import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
+import com.example.picknwhip_be.domain.user.entity.User;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +63,19 @@ public class ReviewConverter {
         .items(items)
         .nextCursor(nextCursor)
         .hasNext(hasNext)
+        .build();
+  }
+
+  public static ReviewLike toReviewLike(Review review, User user) {
+    return ReviewLike.builder().review(review).user(user).build();
+  }
+
+  public static ReviewResDTO.ReviewLikeDTO toReviewLikeDTO(
+      Long reviewId, boolean isLike, Long likeCount) {
+    return ReviewResDTO.ReviewLikeDTO.builder()
+        .reviewId(reviewId)
+        .isLike(isLike)
+        .likeCount(likeCount)
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
@@ -30,4 +30,21 @@ public class ReviewRow {
     @QueryProjection
     public MyReviewSummaryRow {}
   }
+
+  public record ReviewDetailRow(
+      Long reviewId,
+      String nickname,
+      String profileUrl,
+      int rating,
+      String content,
+      LocalDateTime createdAt,
+      String reply) {
+    @QueryProjection
+    public ReviewDetailRow {}
+  }
+
+  public record KeywordRow(Long reviewId, String code, String label) {
+    @QueryProjection
+    public KeywordRow {}
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -40,6 +40,21 @@ public class ReviewResDTO {
       @Schema(description = "다음 커서 값", example = "0") Long nextCursor,
       @Schema(description = "다음 데이터 존재", example = "true") boolean hasNext) {}
 
+  // 리뷰 상세 조회 DTO
+  //    public record ReviewDetailDTO(
+  //            @Schema(description = "리뷰 내용") ReviewDTO review,
+  //            @Schema(description = "닉네임") String Nickname,
+  //            @Schema(description = "프로필 사진 url") String profileUrl,
+  //            @Schema(description = "키워드 목록") List<String> keywords
+  //    ) {}
+
+  // 리뷰 도움 선택/취소 DTO
+  @Builder
+  public record ReviewLikeDTO(
+      @Schema(description = "리뷰 ID") Long reviewId,
+      @Schema(description = "도움이 됐어요 여부") boolean isLike,
+      @Schema(description = "도움이 됐어요 수") Long likeCount) {}
+
   // 홈화면 - 베스트 커스텀 옵션 리뷰 조회 DTO
   @Builder
   public record BestReviewListDTO(

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -40,13 +40,24 @@ public class ReviewResDTO {
       @Schema(description = "다음 커서 값", example = "0") Long nextCursor,
       @Schema(description = "다음 데이터 존재", example = "true") boolean hasNext) {}
 
+  // 리뷰 키워드(code-label)
+  public record KeywordDTO(String code, String label) {}
+
   // 리뷰 상세 조회 DTO
-  //    public record ReviewDetailDTO(
-  //            @Schema(description = "리뷰 내용") ReviewDTO review,
-  //            @Schema(description = "닉네임") String Nickname,
-  //            @Schema(description = "프로필 사진 url") String profileUrl,
-  //            @Schema(description = "키워드 목록") List<String> keywords
-  //    ) {}
+  @Builder
+  public record ReviewDetailDTO(
+      @Schema(description = "리뷰 ID", example = "1") Long reviewId,
+      @Schema(description = "닉네임") String nickname,
+      @Schema(description = "프로필 사진 url") String profileUrl,
+      @Schema(description = "별점", example = "5") int rating,
+      @Schema(description = "리뷰 내용", example = "너무 예쁘고 맛있어요!") String content,
+      @Schema(description = "리뷰 이미지 url 목록", example = "[\"https://....jpg\"]")
+          List<String> imageUrls,
+      @Schema(description = "키워드 목록") List<KeywordDTO> keywords,
+      @Schema(description = "작성일", example = "2026-01-01")
+          @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+          LocalDateTime createdDate,
+      @Schema(description = "사장님 답글", example = "감사합니다.") String reply) {}
 
   // 리뷰 도움 선택/취소 DTO
   @Builder

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
@@ -21,6 +21,8 @@ public enum ReviewErrorCode implements BaseErrorCode {
 
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_2", "리뷰가 존재하지 않습니다."),
 
+  REVIEW_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_3", "취소할 도움이 됐어요가 존재하지 않습니다."),
+
   REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW409_1", "이미 해당 주문에 대한 리뷰가 존재합니다."),
 
   REVIEW_IMAGE_VALIDATION_FAILED(

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
@@ -21,8 +21,6 @@ public enum ReviewErrorCode implements BaseErrorCode {
 
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_2", "리뷰가 존재하지 않습니다."),
 
-  REVIEW_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_3", "취소할 도움이 됐어요가 존재하지 않습니다."),
-
   REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW409_1", "이미 해당 주문에 대한 리뷰가 존재합니다."),
 
   REVIEW_IMAGE_VALIDATION_FAILED(

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewLikeRepository.java
@@ -10,4 +10,10 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("delete from ReviewLike rl where rl.review.id = :reviewId")
   void deleteByReviewId(@Param("reviewId") Long reviewId);
+
+  boolean existsByReviewIdAndUserUserId(Long reviewId, Long userId);
+
+  void deleteByReviewIdAndUserUserId(Long reviewId, Long userId);
+
+  long countByReviewId(Long reviewId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
@@ -13,5 +13,9 @@ public interface ReviewRepositoryCustom {
 
   List<ReviewRow.MyReviewReplyRow> fetchMyReviewReplies(List<Long> reviewIds);
 
+  ReviewRow.ReviewDetailRow fetchReviewDetail(Long reviewId);
+
+  List<ReviewRow.KeywordRow> fetchReviewDetailKeywords(Long reviewId);
+
   List<Review> findBestHelpfulReviews(int limit);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
@@ -6,7 +6,9 @@ import com.example.picknwhip_be.domain.review.dto.*;
 import com.example.picknwhip_be.domain.review.entity.QReview;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewImage;
+import com.example.picknwhip_be.domain.review.entity.mapping.QReviewKeyword;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewReply;
+import com.example.picknwhip_be.domain.review.entity.mapping.QReviewSelectedKeyword;
 import com.example.picknwhip_be.domain.shop.entity.QShop;
 import com.example.picknwhip_be.domain.user.entity.QUser;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,6 +26,9 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
   private static final QReviewReply reviewReply = QReviewReply.reviewReply;
   private static final QUser user = QUser.user;
   private static final QDesignGallery designGallery = QDesignGallery.designGallery;
+  private static final QReviewKeyword reviewKeyword = QReviewKeyword.reviewKeyword;
+  private static final QReviewSelectedKeyword reviewSelectedKeyword =
+      QReviewSelectedKeyword.reviewSelectedKeyword;
 
   @Override
   public ReviewRow.MyReviewSummaryRow fetchMyReviewSummary(Long userId) {
@@ -83,6 +88,39 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         .select(new QReviewRow_MyReviewReplyRow(reviewReply.review.id, reviewReply.content))
         .from(reviewReply)
         .where(reviewReply.review.id.in(reviewIds), reviewReply.deletedAt.isNull())
+        .fetch();
+  }
+
+  @Override
+  public ReviewRow.ReviewDetailRow fetchReviewDetail(Long reviewId) {
+    return queryFactory
+        .select(
+            new QReviewRow_ReviewDetailRow(
+                review.id,
+                user.nickname,
+                user.profileImageUrl,
+                review.rating,
+                review.content,
+                review.createdAt,
+                reviewReply.content))
+        .from(review)
+        .join(review.user, user)
+        .leftJoin(reviewReply)
+        .on(reviewReply.review.id.eq(review.id), reviewReply.deletedAt.isNull())
+        .where(review.id.eq(reviewId), review.deletedAt.isNull())
+        .fetchOne();
+  }
+
+  @Override
+  public List<ReviewRow.KeywordRow> fetchReviewDetailKeywords(Long reviewId) {
+    return queryFactory
+        .select(
+            new QReviewRow_KeywordRow(
+                reviewSelectedKeyword.review.id, reviewKeyword.code, reviewKeyword.label))
+        .from(reviewSelectedKeyword)
+        .join(reviewSelectedKeyword.keyword, reviewKeyword)
+        .where(reviewSelectedKeyword.review.id.eq(reviewId))
+        .orderBy(reviewKeyword.id.asc())
         .fetch();
   }
 

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandService.java
@@ -8,4 +8,8 @@ public interface ReviewCommandService {
   ReviewResDTO.WriteDTO createReview(Long orderId, ReviewReqDTO.WriteDTO dto, Long userId);
 
   Void deleteReview(Long reviewId, Long userId);
+
+  ReviewResDTO.ReviewLikeDTO saveReviewLike(Long reviewId, Long userId);
+
+  ReviewResDTO.ReviewLikeDTO deleteReviewLike(Long reviewId, Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -10,11 +10,16 @@ import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewImage;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewKeyword;
+import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
 import com.example.picknwhip_be.domain.review.exception.ReviewException;
 import com.example.picknwhip_be.domain.review.exception.code.ReviewErrorCode;
 import com.example.picknwhip_be.domain.review.repository.*;
 import com.example.picknwhip_be.domain.review.validator.ReviewImageKeyValidator;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.exception.UserException;
+import com.example.picknwhip_be.domain.user.exception.code.UserErrorCode;
+import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -38,6 +43,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
   private final ReviewReplyRepository reviewReplyRepository;
   private final Clock clock;
   private final ReviewLikeRepository reviewLikeRepository;
+  private final UserRepository userRepository;
 
   @Override
   @Transactional
@@ -118,5 +124,40 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     reviewLikeRepository.deleteByReviewId(reviewId);
 
     return null;
+  }
+
+  @Override
+  @Transactional
+  public ReviewResDTO.ReviewLikeDTO saveReviewLike(Long reviewId, Long userId) {
+    if (!reviewRepository.existsById(reviewId)) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
+    }
+    if (!userRepository.existsById(userId)) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND);
+    }
+
+    boolean alreadyLiked = reviewLikeRepository.existsByReviewIdAndUserUserId(reviewId, userId);
+    if (!alreadyLiked) {
+      try {
+        Review reviewRef = reviewRepository.getReferenceById(reviewId);
+        User userRef = userRepository.getReferenceById(userId);
+
+        ReviewLike reviewLike = ReviewConverter.toReviewLike(reviewRef, userRef);
+        reviewLikeRepository.save(reviewLike);
+      } catch (DataIntegrityViolationException e) {
+        // 동시성으로 이미 생성된 경우: PUT(존재 보장)이므로 성공으로 간주
+      }
+    }
+    long likeCount = reviewLikeRepository.countByReviewId(reviewId);
+
+    return ReviewConverter.toReviewLikeDTO(reviewId, true, likeCount);
+  }
+
+  @Override
+  @Transactional
+  public ReviewResDTO.ReviewLikeDTO deleteReviewLike(Long reviewId, Long userId) {
+    reviewLikeRepository.deleteByReviewIdAndUserUserId(reviewId, userId);
+    long likeCount = reviewLikeRepository.countByReviewId(reviewId);
+    return ReviewConverter.toReviewLikeDTO(reviewId, false, likeCount);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -156,6 +156,13 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
   @Override
   @Transactional
   public ReviewResDTO.ReviewLikeDTO deleteReviewLike(Long reviewId, Long userId) {
+    if (!reviewRepository.existsById(reviewId)) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
+    }
+    if (!userRepository.existsById(userId)) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND);
+    }
+
     reviewLikeRepository.deleteByReviewIdAndUserUserId(reviewId, userId);
     long likeCount = reviewLikeRepository.countByReviewId(reviewId);
     return ReviewConverter.toReviewLikeDTO(reviewId, false, likeCount);

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
@@ -5,5 +5,7 @@ import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 public interface ReviewQueryService {
   ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId);
 
+  ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId, Long userId);
+
   ReviewResDTO.BestReviewListDTO getBestCustomReviews();
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
@@ -5,7 +5,7 @@ import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 public interface ReviewQueryService {
   ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId);
 
-  ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId, Long userId);
+  ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId);
 
   ReviewResDTO.BestReviewListDTO getBestCustomReviews();
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -56,7 +56,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
   }
 
   @Override
-  public ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId, Long userId) {
+  public ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId) {
     ReviewRow.ReviewDetailRow review = reviewRepository.fetchReviewDetail(reviewId);
     List<ReviewRow.KeywordRow> keywordRows = reviewRepository.fetchReviewDetailKeywords(reviewId);
     List<ReviewRow.MyReviewImageRow> imageRows =

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -56,6 +56,29 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
   }
 
   @Override
+  public ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId, Long userId) {
+    ReviewRow.ReviewDetailRow review = reviewRepository.fetchReviewDetail(reviewId);
+    List<ReviewRow.KeywordRow> keywordRows = reviewRepository.fetchReviewDetailKeywords(reviewId);
+    List<ReviewRow.MyReviewImageRow> imageRows =
+        reviewRepository.fetchMyReviewImages(List.of(reviewId));
+    List<String> imageUrls = extractImageUrlsForReview(reviewId, imageRows);
+
+    List<ReviewResDTO.KeywordDTO> keywords =
+        keywordRows.stream().map(k -> new ReviewResDTO.KeywordDTO(k.code(), k.label())).toList();
+
+    return ReviewConverter.toReviewDetailDTO(
+        reviewId,
+        review.rating(),
+        review.content(),
+        review.reply(),
+        imageUrls,
+        review.createdAt(),
+        review.nickname(),
+        review.profileUrl(),
+        keywords);
+  }
+
+  @Override
   public ReviewResDTO.BestReviewListDTO getBestCustomReviews() {
     // 베스트 리뷰 조회
     List<Review> reviews = reviewRepository.findBestHelpfulReviews(5);
@@ -197,5 +220,11 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
   private double roundTo1Decimal(Double avg) {
     double value = (avg == null) ? 0.0 : avg;
     return Math.round(value * 10.0) / 10.0;
+  }
+
+  private List<String> extractImageUrlsForReview(
+      Long reviewId, List<ReviewRow.MyReviewImageRow> imageRows) {
+
+    return groupImageUrlsByReviewId(imageRows).getOrDefault(reviewId, List.of());
   }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #94 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
도움이 됐어요 토글을 어떤 메소드로 구현해야 할지 아주 많은 고민을 하다가.. 정답이 없는 것 같아서 저는 PUT과 DELETE로 분리해 구현해보았습니다. 찾아 보니 PATCH나 POST 하나로 구현하기도 하고, POST/DELETE, PUT/DELETE 다양하더라구요
저는 토글 동작이 중복 요청 및 네트워크 재시도가 빈번하게 발생할 수 있는 특성을 갖기 때문에, 상태를 반전시키는 방식 대신 멱등성 있는 PUT/DELETE로 리소스의 존재를 명시적으로 보장하려고 했습니다.
이로써 동시성 및 재시도 상황에서도 결과 정합성을 유지하고, 불필요한 예외 응답을 줄여 클라이언트 개발 시 혼란을 최소화했습니다.
노션 API 명세서에 개발할 때마다 명세 사항과 테스트 응답 확인하고, 필요한 부분 수정하고 있습니다~

## 🛠️ Changes
- PUT과 DELETE로 리뷰 도움이 됐어요 토글 구현
- 응답으로 리뷰ID, isLike, 해당 리뷰에 대한 도움이 됐어요 개수 반환
- 리뷰 클릭하면 볼 수 있는 상세페이지를 위한 리뷰 상세 정보를 제공하는 API 구현
- 조회 API는 QueryDSL을 이용해 쿼리 작성 후 각 Row에 반환
- 리뷰 키워드와 이미지는 쿼리를 분리하여 성능 개선, 컨버터에서 조회 결과를 결합하는 방식으로 구현

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?