### PR TITLE
[FEAT/#122] 알림 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
@@ -1,0 +1,46 @@
+package com.example.picknwhip_be.domain.notification.controller;
+
+import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import com.example.picknwhip_be.domain.notification.service.query.NotificationQueryService;
+import com.example.picknwhip_be.global.apiPayload.ApiResponse;
+import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Notification", description = "알림 API")
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+  private final NotificationQueryService notificationQueryService;
+
+  @Operation(summary = "알림 목록 조회 by 슝/하승연", description = "알림 화면에서 알림 목록을 조회하는 기능입니다.")
+  @GetMapping("")
+  public ApiResponse<NotiResDTO.NotiListDTO> getNotificationList(
+      @Parameter(description = "조회하려는 탭(디폴트 값은 전체 조회)", example = "ORDER")
+          @RequestParam(required = false)
+          NotificationType notificationType,
+      @Parameter(description = "커서(마지막으로 조회한 notificationId). 첫 조회는 생략", example = "20")
+          @RequestParam(required = false)
+          Long cursor,
+      @Parameter(description = "조회 개수(기본 20, 최대 50)", example = "20")
+          @RequestParam(required = false, defaultValue = "20")
+          @Min(1)
+          @Max(50)
+          int size,
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK,
+        notificationQueryService.getNotificationList(notificationType, cursor, size, userId));
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Notification", description = "알림 API")
 @RestController
 @RequestMapping("/api/notifications")
+@Validated
 @RequiredArgsConstructor
 public class NotificationController {
   private final NotificationQueryService notificationQueryService;

--- a/src/main/java/com/example/picknwhip_be/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/converter/NotificationConverter.java
@@ -20,6 +20,9 @@ public class NotificationConverter {
   public static NotiResDTO.NotiDTO toNotiDTO(Notification notification) {
     return NotiResDTO.NotiDTO.builder()
         .notificationId(notification.getId())
+        .type(notification.getType())
+        .kind(notification.getKind())
+        .targetId(notification.getTargetId())
         .title(notification.getTitle())
         .content(notification.getContent())
         .createdDate(notification.getCreatedAt())

--- a/src/main/java/com/example/picknwhip_be/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,29 @@
+package com.example.picknwhip_be.domain.notification.converter;
+
+import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
+import com.example.picknwhip_be.domain.notification.entity.Notification;
+import java.util.List;
+
+public class NotificationConverter {
+  public static NotiResDTO.NotiListDTO toNotiListDTO(
+      List<Notification> notifications, Long nextCursor, boolean hasNext) {
+    List<NotiResDTO.NotiDTO> items =
+        notifications.stream().map(NotificationConverter::toNotiDTO).toList();
+
+    return NotiResDTO.NotiListDTO.builder()
+        .notifications(items)
+        .nextCursor(nextCursor)
+        .hasNext(hasNext)
+        .build();
+  }
+
+  public static NotiResDTO.NotiDTO toNotiDTO(Notification notification) {
+    return NotiResDTO.NotiDTO.builder()
+        .notificationId(notification.getId())
+        .title(notification.getTitle())
+        .content(notification.getContent())
+        .createdDate(notification.getCreatedAt())
+        .isRead(notification.isRead())
+        .build();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
@@ -1,5 +1,7 @@
 package com.example.picknwhip_be.domain.notification.dto.res;
 
+import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -16,8 +18,9 @@ public class NotiResDTO {
   @Builder
   public record NotiDTO(
       @Schema(description = "알림 ID", example = "1") Long notificationId,
-      @Schema(description = "알림 타입", example = "주문") String type,
-      @Schema(description = "알림 종류", example = "ORDER_SHEET_CHECKING") String kind,
+      @Schema(description = "알림 타입", example = "ORDER") NotificationType type,
+      @Schema(description = "알림 종류", example = "ORDER_SHEET_CHECKING") NotificationKind kind,
+      @Schema(description = "관련 ID(orderId, reviewId, reportId)", example = "1") Long targetId,
       @Schema(description = "제목", example = "주문서가 전달되었습니다") String title,
       @Schema(description = "본문", example = "가게에서 주문서를 확인 후 알려드릴게요!") String content,
       @Schema(description = "발송일", example = "2026-01-01")

--- a/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
@@ -1,0 +1,27 @@
+package com.example.picknwhip_be.domain.notification.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public class NotiResDTO {
+  @Builder
+  public record NotiListDTO(
+      @Schema(description = "알림 목록") List<NotiDTO> notifications,
+      @Schema(description = "다음 커서 값", example = "0") Long nextCursor,
+      @Schema(description = "다음 데이터 존재", example = "true") boolean hasNext) {}
+
+  @Builder
+  public record NotiDTO(
+      @Schema(description = "알림 ID", example = "1") Long notificationId,
+      @Schema(description = "알림 타입", example = "주문") String type,
+      @Schema(description = "알림 종류", example = "ORDER_SHEET_CHECKING") String kind,
+      @Schema(description = "제목", example = "주문서가 전달되었습니다") String title,
+      @Schema(description = "본문", example = "가게에서 주문서를 확인 후 알려드릴게요!") String content,
+      @Schema(description = "발송일", example = "2026-01-01")
+          @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+          LocalDateTime createdDate,
+      @Schema(description = "읽음 여부", example = "false") boolean isRead) {}
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
@@ -1,6 +1,8 @@
 package com.example.picknwhip_be.domain.notification.entity;
 
+import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
 import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,20 +12,32 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Table(name = "notification")
+@Table(
+    name = "notification",
+    indexes = {
+      @Index(name = "idx_notification_user_id_id", columnList = "user_id, id"),
+      @Index(name = "idx_notification_user_id_type_id", columnList = "user_id, type, id")
+    })
 public class Notification extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  //    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  //    @JoinColumn(name = "user_id", nullable = false)
-  //    private User user;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   @Column(name = "type", nullable = false)
   @Enumerated(EnumType.STRING)
   private NotificationType type;
+
+  @Column(name = "kind", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private NotificationKind kind;
+
+  @Column(name = "target_id")
+  private Long targetId;
 
   @Column(name = "title", length = 200, nullable = false)
   private String title;

--- a/src/main/java/com/example/picknwhip_be/domain/notification/enums/NotificationKind.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/enums/NotificationKind.java
@@ -1,0 +1,47 @@
+package com.example.picknwhip_be.domain.notification.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationKind {
+  // ORDER
+  ORDER_SHEET_CHECKING(
+      NotificationType.ORDER, true, "주문서가 전달되었습니다", "${storeName}에서 주문서를 확인 후 알려드릴게요!"),
+  ORDER_PAYMENT_REQUESTED(
+      NotificationType.ORDER, true, "결제가 완료되면 주문이 확정됩니다", "${storeName}에서 주문을 확정했어요.\n결제를 진행해주세요."),
+  ORDER_MAKING(
+      NotificationType.ORDER,
+      true,
+      "사장님이 결제를 확인했어요",
+      "${storeName}에서 케이크 제작을 시작했어요. 조금만 기다려주시면 정성껏 준비해드릴게요!"),
+  ORDER_REJECTED(
+      NotificationType.ORDER, true, "주문 제작이 어려워요", "${storeName}에서 주문서를 확인했습니다. 사장님과 채팅으로 상담해보세요."),
+  ORDER_REJECTED_PAYMENT_FAILED(
+      NotificationType.ORDER,
+      false,
+      "결제가 정상적으로 처리되지 않았어요",
+      "결제가 완료되지 않았거나, 결제 과정에 오류가 있을 수 있으니 다시 결제를 진행해주세요."),
+  ORDER_PICKUP_READY(
+      NotificationType.ORDER,
+      true,
+      "케이크 픽업이 준비되었습니다",
+      "${storeName}에서 케이크가 준비되었어요. 픽업 시간을 확인해주세요."),
+
+  // REVIEW
+  REVIEW_REPLY_CREATED(
+      NotificationType.REVIEW, true, "사장님이 답변을 남겼어요", "작성하신 리뷰에 ${storeName} 사장님이 답변을 남겼습니다."),
+  REVIEW_WRITE_REQUESTED(
+      NotificationType.REVIEW, false, "리뷰를 작성해주세요", "케이크는 어떠셨나요? 소중한 후기를 남겨주세요!"),
+
+  // ETC
+  REPORT_RECEIVED(NotificationType.ETC, false, "신고가 접수되었습니다", "3-5 영업일 내에 검토하여 답변 드리겠습니다."),
+  REPORT_REPLIED(NotificationType.ETC, false, "접수하신 신고에 대해 안내드립니다", "신고하신 내용에 대한 답변 드립니다."),
+  EVENT(NotificationType.ETC, false, "크리스마스 특별 할인", "12월 한정! 크리스마스 케이크 10% 할인 이벤트가 진행중이에요.");
+
+  private final NotificationType type;
+  private final boolean requiredStoreName;
+  private final String titleTemplate;
+  private final String contentTemplate;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/enums/NotificationType.java
@@ -3,5 +3,5 @@ package com.example.picknwhip_be.domain.notification.enums;
 public enum NotificationType {
   ORDER,
   REVIEW,
-  EVENT
+  ETC
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/event/CreateNotificationEvent.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/event/CreateNotificationEvent.java
@@ -1,0 +1,6 @@
+package com.example.picknwhip_be.domain.notification.event;
+
+import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
+
+public record CreateNotificationEvent(
+    Long userId, NotificationKind kind, Long targetId, String storeName) {}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.picknwhip_be.domain.notification.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+  INVALID_NOTIFICATION_KIND(HttpStatus.NOT_FOUND, "NOTIFICATION400_1", "알림 종류 정보가 필요합니다."),
+  INVALID_NOTIFICATION_EVENT(HttpStatus.NOT_FOUND, "NOTIFICATION400_2", "이벤트 정보가 필요합니다."),
+  INVALID_USER_ID(HttpStatus.NOT_FOUND, "NOTIFICATION400_3", "타겟 유저 정보가 필요합니다."),
+  TARGET_ID_NOT_ALLOWED(HttpStatus.NOT_FOUND, "NOTIFICATION403_1", "EVENT는 타겟 ID가 허용되지 않습니다."),
+  TARGET_ID_REQUIRED(HttpStatus.NOT_FOUND, "NOTIFICATION403_2", "타겟 ID가 필요한 알림 타입입니다."),
+  STORE_NAME_REQUIRED(HttpStatus.NOT_FOUND, "NOTIFICATION403_3", "가게명이 필요한 알림 타입입니다."),
+  STORE_NAME_NOT_ALLOWED(HttpStatus.NOT_FOUND, "NOTIFICATION403_4", "가게명이 허용되지 않는 알림 타입입니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404_1", "해당 유저를 찾을 수 없습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationErrorCode.java
@@ -8,13 +8,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum NotificationErrorCode implements BaseErrorCode {
-  INVALID_NOTIFICATION_KIND(HttpStatus.NOT_FOUND, "NOTIFICATION400_1", "알림 종류 정보가 필요합니다."),
-  INVALID_NOTIFICATION_EVENT(HttpStatus.NOT_FOUND, "NOTIFICATION400_2", "이벤트 정보가 필요합니다."),
-  INVALID_USER_ID(HttpStatus.NOT_FOUND, "NOTIFICATION400_3", "타겟 유저 정보가 필요합니다."),
-  TARGET_ID_NOT_ALLOWED(HttpStatus.NOT_FOUND, "NOTIFICATION403_1", "EVENT는 타겟 ID가 허용되지 않습니다."),
-  TARGET_ID_REQUIRED(HttpStatus.NOT_FOUND, "NOTIFICATION403_2", "타겟 ID가 필요한 알림 타입입니다."),
-  STORE_NAME_REQUIRED(HttpStatus.NOT_FOUND, "NOTIFICATION403_3", "가게명이 필요한 알림 타입입니다."),
-  STORE_NAME_NOT_ALLOWED(HttpStatus.NOT_FOUND, "NOTIFICATION403_4", "가게명이 허용되지 않는 알림 타입입니다."),
+  INVALID_NOTIFICATION_KIND(HttpStatus.BAD_REQUEST, "NOTIFICATION400_1", "알림 종류 정보가 필요합니다."),
+  INVALID_NOTIFICATION_EVENT(HttpStatus.BAD_REQUEST, "NOTIFICATION400_2", "이벤트 정보가 필요합니다."),
+  INVALID_USER_ID(HttpStatus.BAD_REQUEST, "NOTIFICATION400_3", "타겟 유저 정보가 필요합니다."),
+  TARGET_ID_NOT_ALLOWED(HttpStatus.FORBIDDEN, "NOTIFICATION403_1", "EVENT는 타겟 ID가 허용되지 않습니다."),
+  TARGET_ID_REQUIRED(HttpStatus.FORBIDDEN, "NOTIFICATION403_2", "타겟 ID가 필요한 알림 타입입니다."),
+  STORE_NAME_REQUIRED(HttpStatus.FORBIDDEN, "NOTIFICATION403_3", "가게명이 필요한 알림 타입입니다."),
+  STORE_NAME_NOT_ALLOWED(HttpStatus.FORBIDDEN, "NOTIFICATION403_4", "가게명이 허용되지 않는 알림 타입입니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404_1", "해당 유저를 찾을 수 없습니다.");
 
   private final HttpStatus status;

--- a/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationException.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.notification.exception.code;
+
+import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+
+public class NotificationException extends GeneralException {
+  public NotificationException(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/listener/NotificationEventListener.java
@@ -4,6 +4,8 @@ import com.example.picknwhip_be.domain.notification.event.CreateNotificationEven
 import com.example.picknwhip_be.domain.notification.service.command.NotificationCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -13,6 +15,7 @@ public class NotificationEventListener {
 
   private final NotificationCommandService notificationCommandService;
 
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handle(CreateNotificationEvent event) {
     notificationCommandService.saveNotification(event);

--- a/src/main/java/com/example/picknwhip_be/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/listener/NotificationEventListener.java
@@ -1,0 +1,20 @@
+package com.example.picknwhip_be.domain.notification.listener;
+
+import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
+import com.example.picknwhip_be.domain.notification.service.command.NotificationCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+  private final NotificationCommandService notificationCommandService;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(CreateNotificationEvent event) {
+    notificationCommandService.saveNotification(event);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.example.picknwhip_be.domain.notification.repository;
+
+import com.example.picknwhip_be.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository
+    extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.picknwhip_be.domain.notification.repository;
+
+import com.example.picknwhip_be.domain.notification.entity.Notification;
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import java.util.List;
+
+public interface NotificationRepositoryCustom {
+  List<Notification> searchNotifications(
+      Long userId, NotificationType type, Long cursor, int limit);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.example.picknwhip_be.domain.notification.repository;
+
+import com.example.picknwhip_be.domain.notification.entity.Notification;
+import com.example.picknwhip_be.domain.notification.entity.QNotification;
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Notification> searchNotifications(
+      Long userId, NotificationType type, Long cursor, int limit) {
+    QNotification n = QNotification.notification;
+
+    BooleanBuilder where = new BooleanBuilder().and(n.user.userId.eq(userId));
+
+    if (type != null) {
+      where.and(n.type.eq(type));
+    }
+    if (cursor != null) {
+      where.and(n.id.lt(cursor));
+    }
+
+    return queryFactory.selectFrom(n).where(where).orderBy(n.id.desc()).limit(limit).fetch();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandService.java
@@ -1,0 +1,9 @@
+package com.example.picknwhip_be.domain.notification.service.command;
+
+import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface NotificationCommandService {
+  @Transactional
+  void saveNotification(CreateNotificationEvent event);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.picknwhip_be.domain.notification.service.command;
+
+import static com.example.picknwhip_be.domain.notification.enums.NotificationKind.EVENT;
+
+import com.example.picknwhip_be.domain.notification.entity.Notification;
+import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
+import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
+import com.example.picknwhip_be.domain.notification.exception.code.NotificationErrorCode;
+import com.example.picknwhip_be.domain.notification.exception.code.NotificationException;
+import com.example.picknwhip_be.domain.notification.repository.NotificationRepository;
+import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationCommandServiceImpl implements NotificationCommandService {
+
+  private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  @Override
+  public void saveNotification(CreateNotificationEvent event) {
+    validateEvent(event);
+
+    NotificationKind kind = event.kind();
+    validateStoreName(kind, event.storeName());
+
+    Long targetId = validateAndResolveTargetId(kind, event.targetId());
+
+    User targetUser =
+        userRepository
+            .findById(event.userId())
+            .orElseThrow(() -> new NotificationException(NotificationErrorCode.USER_NOT_FOUND));
+
+    String title = render(kind.getTitleTemplate(), event.storeName());
+    String content = render(kind.getContentTemplate(), event.storeName());
+
+    Notification notification =
+        Notification.builder()
+            .user(targetUser)
+            .type(kind.getType())
+            .kind(kind)
+            .targetId(targetId)
+            .title(title)
+            .content(content)
+            .build();
+
+    notificationRepository.save(notification);
+  }
+
+  private void validateEvent(CreateNotificationEvent event) {
+    if (event == null) {
+      throw new NotificationException(NotificationErrorCode.INVALID_NOTIFICATION_EVENT);
+    }
+    if (event.userId() == null) {
+      throw new NotificationException(NotificationErrorCode.INVALID_USER_ID);
+    }
+    if (event.kind() == null) {
+      throw new NotificationException(NotificationErrorCode.INVALID_NOTIFICATION_KIND);
+    }
+  }
+
+  private void validateStoreName(NotificationKind kind, String storeName) {
+    if (kind.isRequiredStoreName() && storeName == null) {
+      throw new NotificationException(NotificationErrorCode.STORE_NAME_REQUIRED);
+    }
+    if (!kind.isRequiredStoreName() && storeName != null) {
+      throw new NotificationException(NotificationErrorCode.STORE_NAME_NOT_ALLOWED);
+    }
+  }
+
+  private Long validateAndResolveTargetId(NotificationKind kind, Long targetId) {
+    boolean requiresTargetId = (kind == EVENT) ? false : true;
+
+    if (!requiresTargetId) {
+      if (targetId != null) {
+        throw new NotificationException(NotificationErrorCode.TARGET_ID_NOT_ALLOWED);
+      }
+      return null;
+    }
+
+    if (targetId == null) {
+      throw new NotificationException(NotificationErrorCode.TARGET_ID_REQUIRED);
+    }
+    return targetId;
+  }
+
+  private String render(String template, String storeName) {
+    if (storeName == null) {
+      return template;
+    }
+    return template.replace("${storeName}", storeName);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryService.java
@@ -1,0 +1,9 @@
+package com.example.picknwhip_be.domain.notification.service.query;
+
+import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+
+public interface NotificationQueryService {
+  NotiResDTO.NotiListDTO getNotificationList(
+      NotificationType type, Long cursor, int size, Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.picknwhip_be.domain.notification.service.query;
+
+import com.example.picknwhip_be.domain.notification.converter.NotificationConverter;
+import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
+import com.example.picknwhip_be.domain.notification.entity.Notification;
+import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import com.example.picknwhip_be.domain.notification.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryServiceImpl implements NotificationQueryService {
+  private final NotificationRepository notificationRepository;
+
+  @Override
+  public NotiResDTO.NotiListDTO getNotificationList(
+      NotificationType type, Long cursor, int size, Long userId) {
+    int limit = size + 1;
+    List<Notification> rows =
+        notificationRepository.searchNotifications(userId, type, cursor, limit);
+
+    boolean hasNext = rows.size() > size;
+    List<Notification> items = hasNext ? rows.subList(0, size) : rows;
+    Long nextCursor = items.isEmpty() ? null : items.getLast().getId();
+
+    return NotificationConverter.toNotiListDTO(items, nextCursor, hasNext);
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/report/service/command/ReportCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/report/service/command/ReportCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.picknwhip_be.domain.report.service.command;
 
+import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
+import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
 import com.example.picknwhip_be.domain.report.converter.ReportConverter;
 import com.example.picknwhip_be.domain.report.dto.req.ReportReqDTO;
 import com.example.picknwhip_be.domain.report.entity.Report;
@@ -9,6 +11,7 @@ import com.example.picknwhip_be.domain.report.repository.ReportRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +22,10 @@ public class ReportCommandServiceImpl implements ReportCommandService {
 
   private final ReportRepository reportRepository;
   private final UserQueryService userQueryService;
+  private final ApplicationEventPublisher publisher;
 
   @Override
+  @Transactional
   public Report createReport(Long userId, ReportReqDTO.CreateReportDTO request) {
     User reporter = userQueryService.getUser(userId);
 
@@ -39,6 +44,11 @@ public class ReportCommandServiceImpl implements ReportCommandService {
      */
 
     Report newReport = ReportConverter.toReport(request, reporter);
-    return reportRepository.save(newReport);
+    Report saved = reportRepository.save(newReport);
+    Long reportId = saved.getReportId();
+    publisher.publishEvent(
+        new CreateNotificationEvent(userId, NotificationKind.REPORT_RECEIVED, reportId, null));
+
+    return saved;
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -14,11 +14,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Review", description = "리뷰 API")
 @RestController
 @RequestMapping("/api/reviews")
+@Validated
 @RequiredArgsConstructor
 public class ReviewController {
   private final ReviewCommandService reviewCommandService;

--- a/src/main/resources/db/migration/V13__notification_update.sql
+++ b/src/main/resources/db/migration/V13__notification_update.sql
@@ -1,17 +1,11 @@
 ALTER TABLE notification
-    ADD kind VARCHAR(255) NULL;
+    ADD kind VARCHAR(255) NOT NULL;
 
 ALTER TABLE notification
     ADD target_id BIGINT NULL;
 
 ALTER TABLE notification
-    ADD user_id BIGINT NULL;
-
-ALTER TABLE notification
-    MODIFY kind VARCHAR(255) NOT NULL;
-
-ALTER TABLE notification
-    MODIFY user_id BIGINT NOT NULL;
+    ADD user_id BIGINT NOT NULL;
 
 CREATE INDEX idx_notification_user_id_id ON notification (user_id, id);
 

--- a/src/main/resources/db/migration/V13__notification_update.sql
+++ b/src/main/resources/db/migration/V13__notification_update.sql
@@ -1,0 +1,21 @@
+ALTER TABLE notification
+    ADD kind VARCHAR(255) NULL;
+
+ALTER TABLE notification
+    ADD target_id BIGINT NULL;
+
+ALTER TABLE notification
+    ADD user_id BIGINT NULL;
+
+ALTER TABLE notification
+    MODIFY kind VARCHAR(255) NOT NULL;
+
+ALTER TABLE notification
+    MODIFY user_id BIGINT NOT NULL;
+
+CREATE INDEX idx_notification_user_id_id ON notification (user_id, id);
+
+CREATE INDEX idx_notification_user_id_type_id ON notification (user_id, type, id);
+
+ALTER TABLE notification
+    ADD CONSTRAINT FK_NOTIFICATION_ON_USER FOREIGN KEY (user_id) REFERENCES users (user_id);


### PR DESCRIPTION
## 💡 Issue
- Close #122 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 알림 화면에서 알림 목록을 탭별로 조회하는 API를 커서 페이징으로 구현하였습니다.
- 알림 조회 API는 항상 사용자 기준으로 최신순 + 무한스크롤 형태로 조회되기 때문에 user_id를 선두 컬럼으로 하는 복합 인덱스를 두었고, 탭 필터(type) 유무에 따라 인덱스를 분리해 쿼리 플랜을 안정화했습니다.
- 설계된 알림 종류에 따라 탭은 type, 알림 세부 종류는 kind로 enum 처리하였고, kind별 제목과 본문은 템플릿화하여 에러를 최소화하려고 했습니다.
- 알림 종류에 따라 클라이언트 쪽에서 UI를 다르게 구현하고 클릭하면 리다이렉트되도록 라우팅할 수 있게 kind를 알려주고, 관련 id를 같이 전송하도록 하였습니다.
- 주문, 리뷰, 신고 도메인에서 비즈니스 로직 내에서 처리와 함께 알림을 발송할 수 있도록 이벤트 리스너를 구현하였습니다.
- 본 비즈니스 트랜잭션과 이벤트 리스너가 실행되는 트랜잭션을 분리하여 안정적으로 구동하도록 하였습니다.
- 각 도메인에서 간단한 코드를 추가하여 구현할 수 있으며, 현재 코드에 존재하는 신고 제출 시 실행되는 createReport를 예시로 구현해두었습니다. 아직 구현되지 않은 곳은 담당자분께서 로직 구현하시면서 끝에 코드 추가해주시면 될 것 같습니다.(ReportCommandServiceImpl을 참고해주세요!)

## 🛠️ Changes
- 알림 엔티티 주석 해제 및 인덱스 설정으로 조회 성능 개선
- 알림 종류(NotificationKind) enum을 작성하여 알림 종류에 따른 구분과 내용 템플릿 제공
- 알림 엔티티에 kind와 targetId를 넣어 클릭하면 리다이렉트 가능하도록 정보 저장
- QueryDSL을 이용해 알림 목록 조회 쿼리 작성
- 커서 기반 페이지네이션으로 탭별로 목록 조회 구현
- 마이그레이션 파일 ~V12~ V13 작성
- 각 도메인에서 알림을 발송하기 위한 이벤트 및 이벤트 리스너 코드 작성
- 알림 저장을 위한 Service 구현
- 발생할 수 있는 예외 핸들링 처리
- 예시로 createReport 시 발송해야 하는 알림 발송 구현
- 이벤트는 해당 save 이후 새로운 트랜잭션으로 실행되도록 안정화
- 빠진 컨버터 및 DTO 코드 추가

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?