### PR TITLE
[FEAT] 채팅방 주문 내역 공유 기능

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
@@ -4,14 +4,28 @@ import com.example.picknwhip_be.domain.chat.dto.req.ChatReqDTO;
 import com.example.picknwhip_be.domain.chat.dto.res.ChatResDTO;
 import com.example.picknwhip_be.domain.chat.entity.ChatMessage;
 import com.example.picknwhip_be.domain.chat.entity.ChatRoom;
+import com.example.picknwhip_be.domain.order.entity.Order;
 import com.example.picknwhip_be.domain.user.entity.User;
 import java.util.List;
 
 public class ChatConverter {
-  public static ChatResDTO.RoomInfo toRoomInfo(ChatRoom room) {
+  public static ChatResDTO.RoomInfo toRoomInfo(ChatRoom room, Order order) {
     return ChatResDTO.RoomInfo.builder()
         .roomId(room.getChatRoomId())
         .shopName(room.getShop().getShopName())
+        .orderSummary(order != null ? toOrderSummary(order) : null)
+        .build();
+  }
+
+  public static ChatResDTO.OrderSummary toOrderSummary(Order order) {
+    if (order == null) return null;
+    return ChatResDTO.OrderSummary.builder()
+        .orderId(order.getId())
+        .orderCode(order.getOrderCode())
+        .cakeSize(order.getShopCakeSize().getSizeName())
+        .pickupDatetime(order.getPickupDatetime().toString())
+        .totalPrice(order.getTotalPrice())
+        .status(order.getStatus().name())
         .build();
   }
 

--- a/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
@@ -23,10 +23,7 @@ public class ChatConverter {
         .orderId(order.getId())
         .orderCode(order.getOrderCode())
         .cakeSize(order.getShopCakeSize().getSizeName())
-        .pickupDatetime(
-            order
-                .getPickupDatetime()
-                .format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+        .pickupDatetime(order.getPickupDatetime())
         .totalPrice(order.getTotalPrice())
         .status(order.getStatus().name())
         .build();

--- a/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/converter/ChatConverter.java
@@ -23,7 +23,10 @@ public class ChatConverter {
         .orderId(order.getId())
         .orderCode(order.getOrderCode())
         .cakeSize(order.getShopCakeSize().getSizeName())
-        .pickupDatetime(order.getPickupDatetime().toString())
+        .pickupDatetime(
+            order
+                .getPickupDatetime()
+                .format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME))
         .totalPrice(order.getTotalPrice())
         .status(order.getStatus().name())
         .build();

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/req/ChatReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/req/ChatReqDTO.java
@@ -11,6 +11,7 @@ public class ChatReqDTO {
   @AllArgsConstructor
   public static class CreateRoom {
     private Long shopId;
+    private Long orderId;
   }
 
   @Getter

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResDTO.java
@@ -1,6 +1,7 @@
 package com.example.picknwhip_be.domain.chat.dto.res;
 
 import com.example.picknwhip_be.domain.chat.entity.MessageType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -27,7 +28,13 @@ public class ChatResDTO {
     private Long orderId;
     private String orderCode;
     private String cakeSize;
-    private String pickupDatetime;
+
+    @JsonFormat(
+        shape = JsonFormat.Shape.STRING,
+        pattern = "yyyy-MM-dd HH:mm:ss",
+        timezone = "Asia/Seoul")
+    private LocalDateTime pickupDatetime;
+
     private int totalPrice;
     private String status;
   }

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResDTO.java
@@ -16,6 +16,20 @@ public class ChatResDTO {
   public static class RoomInfo {
     private Long roomId;
     private String shopName;
+    private OrderSummary orderSummary;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class OrderSummary {
+    private Long orderId;
+    private String orderCode;
+    private String cakeSize;
+    private String pickupDatetime;
+    private int totalPrice;
+    private String status;
   }
 
   @Builder

--- a/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/dto/res/ChatResDTO.java
@@ -29,10 +29,7 @@ public class ChatResDTO {
     private String orderCode;
     private String cakeSize;
 
-    @JsonFormat(
-        shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd HH:mm:ss",
-        timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDateTime pickupDatetime;
 
     private int totalPrice;

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/command/ChatCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/command/ChatCommandServiceImpl.java
@@ -69,6 +69,10 @@ public class ChatCommandServiceImpl implements ChatCommandService {
       if (!order.getUser().getUserId().equals(customerId)) {
         throw new OrderException(OrderErrorCode.FORBIDDEN_ACCESS);
       }
+
+      if (!order.getShop().getId().equals(shop.getId())) {
+        throw new OrderException(OrderErrorCode.INVALID_ORDER_CONTEXT);
+      }
     }
 
     return ChatConverter.toRoomInfo(room, order);

--- a/src/main/java/com/example/picknwhip_be/domain/chat/service/command/ChatCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/chat/service/command/ChatCommandServiceImpl.java
@@ -11,6 +11,10 @@ import com.example.picknwhip_be.domain.chat.exception.ChatException;
 import com.example.picknwhip_be.domain.chat.exception.code.ChatErrorCode;
 import com.example.picknwhip_be.domain.chat.repository.ChatMessageRepository;
 import com.example.picknwhip_be.domain.chat.repository.ChatRoomRepository;
+import com.example.picknwhip_be.domain.order.entity.Order;
+import com.example.picknwhip_be.domain.order.exception.OrderException;
+import com.example.picknwhip_be.domain.order.exception.code.OrderErrorCode;
+import com.example.picknwhip_be.domain.order.repository.OrderRepository;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
@@ -33,6 +37,7 @@ public class ChatCommandServiceImpl implements ChatCommandService {
   private final UserRepository userRepository;
   private final ShopRepository shopRepository;
   private final S3Service s3Service;
+  private final OrderRepository orderRepository;
 
   @Override
   public ChatResDTO.RoomInfo saveOrCreateRoom(ChatReqDTO.CreateRoom dto, Long customerId) {
@@ -53,7 +58,20 @@ public class ChatCommandServiceImpl implements ChatCommandService {
                     chatRoomRepository.save(
                         ChatRoom.builder().customer(customer).shop(shop).build()));
 
-    return ChatConverter.toRoomInfo(room);
+    // 요청에 orderId가 포함되어 있다면 해당 주문 정보 조회
+    Order order = null;
+    if (dto.getOrderId() != null) {
+      order =
+          orderRepository
+              .findById(dto.getOrderId())
+              .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+      if (!order.getUser().getUserId().equals(customerId)) {
+        throw new OrderException(OrderErrorCode.FORBIDDEN_ACCESS);
+      }
+    }
+
+    return ChatConverter.toRoomInfo(room, order);
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/domain/order/exception/code/OrderErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/order/exception/code/OrderErrorCode.java
@@ -11,7 +11,9 @@ public enum OrderErrorCode implements BaseErrorCode {
   FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "ORDER403", "해당 주문 정보에 접근 권한이 없습니다."),
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER404_1", "해당 주문을 찾을 수 없습니다."),
   SLOT_ALREADY_FULL(HttpStatus.CONFLICT, "ORDER409_1", "선택하신 픽업 시간은 이미 마감되었습니다. 다른 시간을 선택해주세요."),
-  INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER400_1", "유효하지 않은 주문 상태입니다.");
+  INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER400_1", "유효하지 않은 주문 상태입니다."),
+  INVALID_ORDER_CONTEXT(HttpStatus.BAD_REQUEST, "ORDER400", "해당 가게의 주문 정보가 아닙니다."),
+  ;
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/example/picknwhip_be/domain/order/exception/code/OrderErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/order/exception/code/OrderErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum OrderErrorCode implements BaseErrorCode {
+  FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "ORDER403", "해당 주문 정보에 접근 권한이 없습니다."),
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER404_1", "해당 주문을 찾을 수 없습니다."),
   SLOT_ALREADY_FULL(HttpStatus.CONFLICT, "ORDER409_1", "선택하신 픽업 시간은 이미 마감되었습니다. 다른 시간을 선택해주세요."),
   INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER400_1", "유효하지 않은 주문 상태입니다.");


### PR DESCRIPTION
## 💡 Issue
- Close #127

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 주문 상세 페이지에서 채팅방 생성 시 해당 주문 정보를 채팅방 상단에 고정
- 어떤 이유로 수정했는지 적어주세요.

## 🛠️ Changes
- [x] Chat DTO에 orderId 필드 추가 및 주문 요약 정보를 담는 OrderSummary DTO 추가
- [x] ChatCommandServiceImpl에서 데이터 연동 로직 구현
- [x] ChatConverter에 주문 엔티티를 요약 DTO로 변환하는 매핑 로직 구현
- [x] OrderErrorCode 예외 처리 추가

## 📸 Screenshots
<img width="478" height="338" alt="스크린샷 2026-02-04 19 45 26" src="https://github.com/user-attachments/assets/2f1c38ac-e7ab-42fb-a7af-0c3676928513" />


## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?