### PR TITLE
[FEAT/#125] 알림 읽음 관련 API 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
@@ -62,10 +62,9 @@ public class NotificationController {
   }
 
   @Operation(summary = "알림 하나 읽음 by 슝/하승연", description = "회원이 알림창에서 특정한 알림 하나를 읽음 처리하는 기능입니다.")
-  @PatchMapping("/{id}/read")
-  public ApiResponse<NotiResDTO.readDTO> updateNotificationRead(
-      @PathVariable("id") Long notificationId,
-      @Parameter(hidden = true) @ExtractPayload Long userId) {
+  @PatchMapping("/{notificationId}/read")
+  public ApiResponse<NotiResDTO.ReadDTO> updateNotificationRead(
+      @PathVariable Long notificationId, @Parameter(hidden = true) @ExtractPayload Long userId) {
     return ApiResponse.of(
         GeneralSuccessCode.OK,
         notificationCommandService.updateNotificationRead(notificationId, userId));

--- a/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
@@ -64,7 +64,8 @@ public class NotificationController {
   @Operation(summary = "알림 하나 읽음 by 슝/하승연", description = "회원이 알림창에서 특정한 알림 하나를 읽음 처리하는 기능입니다.")
   @PatchMapping("/{id}/read")
   public ApiResponse<NotiResDTO.readDTO> updateNotificationRead(
-      @RequestParam Long notificationId, @Parameter(hidden = true) @ExtractPayload Long userId) {
+      @PathVariable("id") Long notificationId,
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
     return ApiResponse.of(
         GeneralSuccessCode.OK,
         notificationCommandService.updateNotificationRead(notificationId, userId));

--- a/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
@@ -45,4 +45,12 @@ public class NotificationController {
         GeneralSuccessCode.OK,
         notificationQueryService.getNotificationList(notificationType, cursor, size, userId));
   }
+
+  @Operation(summary = "알림 안 읽음 개수 조회 by 슝/하승연", description = "알림 화면에서 안 읽음 알림 개수를 조회하는 기능입니다. ")
+  @GetMapping("/unread")
+  public ApiResponse<NotiResDTO.UnreadDTO> getUnreadCount(
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, notificationQueryService.searchUnreadCount(userId));
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.example.picknwhip_be.domain.notification.controller;
 
 import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
 import com.example.picknwhip_be.domain.notification.enums.NotificationType;
+import com.example.picknwhip_be.domain.notification.service.command.NotificationCommandService;
 import com.example.picknwhip_be.domain.notification.service.query.NotificationQueryService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
@@ -13,10 +14,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Notification", description = "알림 API")
 @RestController
@@ -25,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class NotificationController {
   private final NotificationQueryService notificationQueryService;
+  private final NotificationCommandService notificationCommandService;
 
   @Operation(summary = "알림 목록 조회 by 슝/하승연", description = "알림 화면에서 알림 목록을 조회하는 기능입니다.")
   @GetMapping("")
@@ -46,11 +45,28 @@ public class NotificationController {
         notificationQueryService.getNotificationList(notificationType, cursor, size, userId));
   }
 
-  @Operation(summary = "알림 안 읽음 개수 조회 by 슝/하승연", description = "알림 화면에서 안 읽음 알림 개수를 조회하는 기능입니다. ")
+  @Operation(summary = "알림 안 읽음 개수 조회 by 슝/하승연", description = "알림 화면에서 안 읽음 알림 개수를 조회하는 기능입니다.")
   @GetMapping("/unread")
   public ApiResponse<NotiResDTO.UnreadDTO> getUnreadCount(
       @Parameter(hidden = true) @ExtractPayload Long userId) {
     return ApiResponse.of(
         GeneralSuccessCode.OK, notificationQueryService.searchUnreadCount(userId));
+  }
+
+  @Operation(summary = "알림 전체 읽음 by 슝/하승연", description = "회원의 알림 화면에 나타난 알림을 모두 읽음 표시하는 기능입니다.")
+  @PatchMapping("/read-all")
+  public ApiResponse<Void> updateNotificationReadAll(
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
+    notificationCommandService.updateNotificationReadAll(userId);
+    return ApiResponse.of(GeneralSuccessCode.OK);
+  }
+
+  @Operation(summary = "알림 하나 읽음 by 슝/하승연", description = "회원이 알림창에서 특정한 알림 하나를 읽음 처리하는 기능입니다.")
+  @PatchMapping("/{id}/read")
+  public ApiResponse<NotiResDTO.readDTO> updateNotificationRead(
+      @RequestParam Long notificationId, @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK,
+        notificationCommandService.updateNotificationRead(notificationId, userId));
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
@@ -28,9 +28,7 @@ public class NotiResDTO {
           LocalDateTime createdDate,
       @Schema(description = "읽음 여부", example = "false") boolean isRead) {}
 
-  @Builder
   public record UnreadDTO(@Schema(description = "알림 안 읽음 개수", example = "1") Long unread) {}
 
-  @Builder
-  public record readDTO(@Schema(description = "읽은 알림 ID", example = "1") Long notificationId) {}
+  public record ReadDTO(@Schema(description = "읽은 알림 ID", example = "1") Long notificationId) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
@@ -27,4 +27,7 @@ public class NotiResDTO {
           @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
           LocalDateTime createdDate,
       @Schema(description = "읽음 여부", example = "false") boolean isRead) {}
+
+  @Builder
+  public record UnreadDTO(@Schema(description = "알림 안 읽음 개수", example = "1") Long unread) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/dto/res/NotiResDTO.java
@@ -30,4 +30,7 @@ public class NotiResDTO {
 
   @Builder
   public record UnreadDTO(@Schema(description = "알림 안 읽음 개수", example = "1") Long unread) {}
+
+  @Builder
+  public record readDTO(@Schema(description = "읽은 알림 ID", example = "1") Long notificationId) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/entity/Notification.java
@@ -48,4 +48,10 @@ public class Notification extends BaseEntity {
   @Column(name = "is_read", nullable = false)
   @Builder.Default
   private boolean isRead = false;
+
+  public void markAsRead() {
+    if (!this.isRead) {
+      this.isRead = true;
+    }
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/exception/NotificationException.java
@@ -1,4 +1,4 @@
-package com.example.picknwhip_be.domain.notification.exception.code;
+package com.example.picknwhip_be.domain.notification.exception;
 
 import com.example.picknwhip_be.global.apiPayload.code.BaseErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;

--- a/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/exception/code/NotificationErrorCode.java
@@ -15,8 +15,8 @@ public enum NotificationErrorCode implements BaseErrorCode {
   TARGET_ID_REQUIRED(HttpStatus.FORBIDDEN, "NOTIFICATION403_2", "타겟 ID가 필요한 알림 타입입니다."),
   STORE_NAME_REQUIRED(HttpStatus.FORBIDDEN, "NOTIFICATION403_3", "가게명이 필요한 알림 타입입니다."),
   STORE_NAME_NOT_ALLOWED(HttpStatus.FORBIDDEN, "NOTIFICATION403_4", "가게명이 허용되지 않는 알림 타입입니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404_1", "해당 유저를 찾을 수 없습니다.");
-
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404_1", "해당 유저를 찾을 수 없습니다."),
+  NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404_2", "해당 알림을 찾을 수 없습니다.");
   private final HttpStatus status;
   private final String code;
   private final String message;

--- a/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepository.java
@@ -1,9 +1,25 @@
 package com.example.picknwhip_be.domain.notification.repository;
 
 import com.example.picknwhip_be.domain.notification.entity.Notification;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository
     extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
   Long countByUserUserIdAndIsReadFalse(Long userId);
+
+  Optional<Notification> findByIdAndUserUserId(Long id, Long userId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      """
+    update Notification n
+       set n.isRead = true
+     where n.user.userId = :userId
+       and n.isRead = false
+""")
+  int markAllAsRead(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/repository/NotificationRepository.java
@@ -4,4 +4,6 @@ import com.example.picknwhip_be.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository
-    extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {}
+    extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+  Long countByUserUserIdAndIsReadFalse(Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandService.java
@@ -1,9 +1,16 @@
 package com.example.picknwhip_be.domain.notification.service.command;
 
+import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
 import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface NotificationCommandService {
   @Transactional
   void saveNotification(CreateNotificationEvent event);
+
+  @Transactional
+  void updateNotificationReadAll(Long userId);
+
+  @Transactional
+  NotiResDTO.readDTO updateNotificationRead(Long notificationId, Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandService.java
@@ -12,5 +12,5 @@ public interface NotificationCommandService {
   void updateNotificationReadAll(Long userId);
 
   @Transactional
-  NotiResDTO.readDTO updateNotificationRead(Long notificationId, Long userId);
+  NotiResDTO.ReadDTO updateNotificationRead(Long notificationId, Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -2,11 +2,12 @@ package com.example.picknwhip_be.domain.notification.service.command;
 
 import static com.example.picknwhip_be.domain.notification.enums.NotificationKind.EVENT;
 
+import com.example.picknwhip_be.domain.notification.dto.res.NotiResDTO;
 import com.example.picknwhip_be.domain.notification.entity.Notification;
 import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
 import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
+import com.example.picknwhip_be.domain.notification.exception.NotificationException;
 import com.example.picknwhip_be.domain.notification.exception.code.NotificationErrorCode;
-import com.example.picknwhip_be.domain.notification.exception.code.NotificationException;
 import com.example.picknwhip_be.domain.notification.repository.NotificationRepository;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
@@ -94,5 +95,25 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
       return template;
     }
     return template.replace("${storeName}", storeName);
+  }
+
+  @Transactional
+  @Override
+  public void updateNotificationReadAll(Long userId) {
+    notificationRepository.markAllAsRead(userId);
+  }
+
+  @Transactional
+  @Override
+  public NotiResDTO.readDTO updateNotificationRead(Long notificationId, Long userId) {
+    Notification notification =
+        notificationRepository
+            .findByIdAndUserUserId(notificationId, userId)
+            .orElseThrow(
+                () -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+    notification.markAsRead();
+
+    return NotiResDTO.readDTO.builder().notificationId(notificationId).build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -105,7 +105,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
   @Transactional
   @Override
-  public NotiResDTO.readDTO updateNotificationRead(Long notificationId, Long userId) {
+  public NotiResDTO.ReadDTO updateNotificationRead(Long notificationId, Long userId) {
     Notification notification =
         notificationRepository
             .findByIdAndUserUserId(notificationId, userId)
@@ -114,6 +114,6 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
     notification.markAsRead();
 
-    return NotiResDTO.readDTO.builder().notificationId(notificationId).build();
+    return new NotiResDTO.ReadDTO(notificationId);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryService.java
@@ -6,4 +6,6 @@ import com.example.picknwhip_be.domain.notification.enums.NotificationType;
 public interface NotificationQueryService {
   NotiResDTO.NotiListDTO getNotificationList(
       NotificationType type, Long cursor, int size, Long userId);
+
+  NotiResDTO.UnreadDTO searchUnreadCount(Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryServiceImpl.java
@@ -27,4 +27,10 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
 
     return NotificationConverter.toNotiListDTO(items, nextCursor, hasNext);
   }
+
+  @Override
+  public NotiResDTO.UnreadDTO searchUnreadCount(Long userId) {
+    Long count = notificationRepository.countByUserUserIdAndIsReadFalse(userId);
+    return NotiResDTO.UnreadDTO.builder().unread(count).build();
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/notification/service/query/NotificationQueryServiceImpl.java
@@ -31,6 +31,6 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
   @Override
   public NotiResDTO.UnreadDTO searchUnreadCount(Long userId) {
     Long count = notificationRepository.countByUserUserIdAndIsReadFalse(userId);
-    return NotiResDTO.UnreadDTO.builder().unread(count).build();
+    return new NotiResDTO.UnreadDTO(count);
   }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #125 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 알림 화면에서 사용하는 읽음 관련 API들 구현했습니다!
- 전체 읽음은 벌크 쿼리로 구현하였고, 나머지는 모두 간단하게 메소드 이름으로 해결했습니당

## 🛠️ Changes
- 알림 안 읽음 개수 조회 API
- 알림 하나 읽음 API
- 알림 전체 읽음 API

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?