### PR TITLE
[FEAT/#129] 가게 리뷰 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 
 .DS_Store
 
-./claude
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 .env
 
 .DS_Store
+
+./claude

--- a/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
@@ -5,6 +5,7 @@ import com.example.picknwhip_be.domain.custom.dto.res.CustomResDTO;
 import com.example.picknwhip_be.domain.design.dto.res.DesignResDTO;
 import com.example.picknwhip_be.domain.design.entity.DesignGallery;
 import com.example.picknwhip_be.domain.design.entity.mapping.DesignOption;
+import com.example.picknwhip_be.domain.design.enums.Style;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,7 +17,7 @@ public class DesignConverter {
         .cakeName(designGallery.getDesignName())
         .price(designGallery.getBasePrice())
         .imageUrl(designGallery.getImageUrl())
-        .keywords(designGallery.getKeywords())
+        .keywords(designGallery.getKeywords().stream().map(Style::getLabel).toList())
         .build();
   }
 
@@ -59,7 +60,7 @@ public class DesignConverter {
         .letteringText(design.getLetteringText())
         .letteringAlignment(design.getLetteringAlignment())
         .letteringLineCount(design.getLetteringLineCount())
-        .keywords(design.getKeywords())
+        .keywords(design.getKeywords().stream().map(Style::getLabel).toList())
         .toppings(toppings)
         .options(options)
         .build();

--- a/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
@@ -1,13 +1,16 @@
 package com.example.picknwhip_be.domain.design.entity;
 
 import com.example.picknwhip_be.domain.design.entity.mapping.DesignOption;
+import com.example.picknwhip_be.domain.design.enums.Style;
 import com.example.picknwhip_be.domain.order.entity.enums.LetteringAlignment;
 import com.example.picknwhip_be.domain.order.entity.enums.LetteringLineCount;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.entity.ShopCakeSize;
 import jakarta.persistence.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.*;
 
 @Entity
@@ -60,8 +63,10 @@ public class DesignGallery {
   @CollectionTable(
       name = "design_gallery_keywords",
       joinColumns = @JoinColumn(name = "design_gallery_id"))
+  @Enumerated(EnumType.STRING)
   @Column(name = "keyword")
-  private List<String> keywords;
+  @Builder.Default
+  private Set<Style> keywords = new HashSet<>();
 
   @OneToMany(mappedBy = "designGallery", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default

--- a/src/main/java/com/example/picknwhip_be/domain/design/enums/Style.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/enums/Style.java
@@ -1,0 +1,54 @@
+package com.example.picknwhip_be.domain.design.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Style {
+
+  // 디자인 스타일
+  MINIMAL("미니멀"),
+  GORGEOUS("화려한"),
+  VINTAGE("빈티지"),
+  MODERN("모던"),
+  LOVELY("러블리"),
+  ANTIQUE("앤틱"),
+  SIMPLE("심플"),
+  LUXURY("럭셔리"),
+
+  // 케이크 형태
+  ROUND("원형"),
+  HEART("하트"),
+  SQUARE("사각"),
+
+  // 맛 / 베이스
+  VANILLA("바닐라"),
+  CHOCOLATE("초콜릿"),
+  STRAWBERRY("딸기"),
+  MATCHA("말차"),
+  CHEESE("치즈"),
+  TIRAMISU("티라미수"),
+  RED_VELVET("레드벨벳"),
+  CARROT("당근"),
+  EARL_GREY("얼그레이"),
+
+  // 토핑 / 데코레이션
+  FRESH_FRUIT("생과일"),
+  MACARON("마카롱"),
+  FLOWER("생화"),
+  FIGURINE("조화"),
+  GOLD_LEAF("금박"),
+  CHOCOLATE_TOPPING("초콜릿"),
+  COOKIE("쿠키"),
+  MERINGUE("머랭"),
+
+  // 특별 옵션
+  PHOTO_CAKE("포토케이크"),
+  LETTERING("레터링"),
+  IDOL("아이돌"),
+  GLUTEN_FREE("글루텐프리"),
+  VEGAN("비건");
+
+  private final String label;
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class ReviewConverter {
   public static ReviewResDTO.WriteDTO toWriteDTO(Long reviewId) {
@@ -100,6 +101,40 @@ public class ReviewConverter {
         .keywords(keywords)
         .createdDate(createdDate)
         .reply(reply)
+        .build();
+  }
+
+  public static ReviewResDTO.ShopReviewListDTO toShopReviewListDTO(
+      List<ReviewRow.ShopReviewRow> rows,
+      Map<Long, List<String>> imageUrlsByReviewId,
+      Map<Long, List<ReviewResDTO.KeywordDTO>> keywordsByReviewId,
+      Set<Long> likedReviewIds,
+      String nextCursor,
+      boolean hasNext) {
+
+    List<ReviewResDTO.ShopReviewItemDTO> items =
+        rows.stream()
+            .map(
+                r ->
+                    ReviewResDTO.ShopReviewItemDTO.builder()
+                        .reviewId(r.reviewId())
+                        .nickname(r.nickname())
+                        .profileUrl(r.profileUrl())
+                        .rating(r.rating())
+                        .option(r.option())
+                        .content(r.content())
+                        .imageUrls(imageUrlsByReviewId.getOrDefault(r.reviewId(), List.of()))
+                        .keywords(keywordsByReviewId.getOrDefault(r.reviewId(), List.of()))
+                        .isLike(likedReviewIds.contains(r.reviewId()))
+                        .likeCount((long) r.likeCount())
+                        .createdDate(r.createdDate())
+                        .build())
+            .toList();
+
+    return ReviewResDTO.ShopReviewListDTO.builder()
+        .items(items)
+        .nextCursor(nextCursor)
+        .hasNext(hasNext)
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
@@ -3,7 +3,7 @@ package com.example.picknwhip_be.domain.review.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 
-// 작성한 리뷰 목록 조회 응답을 위한 중간 조회 전용 DTO 모음
+// 중간 조회 전용 DTO 모음
 public class ReviewRow {
   public record MyReviewRow(
       Long reviewId,
@@ -46,5 +46,18 @@ public class ReviewRow {
   public record KeywordRow(Long reviewId, String code, String label) {
     @QueryProjection
     public KeywordRow {}
+  }
+
+  public record ShopReviewRow(
+      Long reviewId,
+      String nickname,
+      String profileUrl,
+      int rating,
+      String option,
+      String content,
+      int likeCount,
+      LocalDateTime createdDate) {
+    @QueryProjection
+    public ShopReviewRow {}
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/req/ReviewReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/req/ReviewReqDTO.java
@@ -1,5 +1,7 @@
 package com.example.picknwhip_be.domain.review.dto.req;
 
+import com.example.picknwhip_be.domain.design.enums.Style;
+import com.example.picknwhip_be.domain.review.enums.ReviewSort;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import java.util.List;
@@ -20,4 +22,16 @@ public class ReviewReqDTO {
           @Size(max = 5)
           List<String> imageKeys,
       @Schema(description = "옵션 공개 동의 여부", example = "true") Boolean agreement) {}
+
+  // 가게 리뷰 목록 조회 DTO
+  public record ShopReviewListDTO(
+      @Schema(description = "정렬 방식", example = "LATEST", defaultValue = "LATEST") ReviewSort sort,
+      @Schema(description = "디자인 갤러리 필터(디자인 ID)", example = "[\"1\", \"3\"]") List<Long> designIds,
+      @Schema(description = "스타일 필터", example = "[\"MINIMAL\",\"ROUND\",\"IDOL\"]")
+          List<Style> styles,
+      @Schema(description = "커서(NextCursor). 첫 조회는 생략") String cursor,
+      @Schema(description = "조회 개수(기본 20, 최대 50)", example = "20", defaultValue = "20")
+          @Min(1)
+          @Max(50)
+          Integer size) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -66,6 +66,30 @@ public class ReviewResDTO {
       @Schema(description = "도움이 됐어요 여부") boolean isLike,
       @Schema(description = "도움이 됐어요 수") Long likeCount) {}
 
+  // 가게 리뷰 목록 DTO
+  @Builder
+  public record ShopReviewListDTO(
+      @Schema(description = "리뷰 목록") List<ShopReviewItemDTO> items,
+      @Schema(description = "다음 커서 값", example = "0") String nextCursor,
+      @Schema(description = "다음 데이터 존재", example = "true") boolean hasNext) {}
+
+  @Builder
+  public record ShopReviewItemDTO(
+      @Schema(description = "리뷰 ID", example = "1") Long reviewId,
+      @Schema(description = "닉네임") String nickname,
+      @Schema(description = "프로필 사진 url") String profileUrl,
+      @Schema(description = "별점", example = "5") int rating,
+      @Schema(description = "케이크 옵션", example = "기념일 케이크") String option,
+      @Schema(description = "리뷰 내용", example = "너무 예쁘고 맛있어요!") String content,
+      @Schema(description = "리뷰 이미지 url 목록", example = "[\"https://....jpg\"]")
+          List<String> imageUrls,
+      @Schema(description = "키워드 목록") List<KeywordDTO> keywords,
+      @Schema(description = "도움이 됐어요 여부") boolean isLike,
+      @Schema(description = "도움이 됐어요 수") Long likeCount,
+      @Schema(description = "작성일", example = "2026-01-01")
+          @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+          LocalDateTime createdDate) {}
+
   // 홈화면 - 베스트 커스텀 옵션 리뷰 조회 DTO
   @Builder
   public record BestReviewListDTO(

--- a/src/main/java/com/example/picknwhip_be/domain/review/enums/ReviewSort.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/enums/ReviewSort.java
@@ -1,0 +1,8 @@
+package com.example.picknwhip_be.domain.review.enums;
+
+public enum ReviewSort {
+  LATEST,
+  HELPFUL,
+  RATING_HIGH,
+  RATING_LOW
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/exception/code/ReviewErrorCode.java
@@ -21,6 +21,8 @@ public enum ReviewErrorCode implements BaseErrorCode {
 
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_2", "리뷰가 존재하지 않습니다."),
 
+  INVALID_CURSOR(HttpStatus.BAD_REQUEST, "REVIEW400_4", "유효하지 않은 커서 값입니다."),
+
   REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW409_1", "이미 해당 주문에 대한 리뷰가 존재합니다."),
 
   REVIEW_IMAGE_VALIDATION_FAILED(

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,8 +1,12 @@
 package com.example.picknwhip_be.domain.review.repository;
 
+import com.example.picknwhip_be.domain.design.enums.Style;
 import com.example.picknwhip_be.domain.review.dto.ReviewRow;
 import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.review.enums.ReviewSort;
+import com.example.picknwhip_be.domain.review.service.query.cursor.ReviewCursor;
 import java.util.List;
+import java.util.Set;
 
 public interface ReviewRepositoryCustom {
   ReviewRow.MyReviewSummaryRow fetchMyReviewSummary(Long userId);
@@ -17,5 +21,17 @@ public interface ReviewRepositoryCustom {
 
   List<ReviewRow.KeywordRow> fetchReviewDetailKeywords(Long reviewId);
 
+  List<ReviewRow.KeywordRow> fetchReviewKeywords(List<Long> reviewIds);
+
   List<Review> findBestHelpfulReviews(int limit);
+
+  List<ReviewRow.ShopReviewRow> fetchShopReviewRows(
+      Long shopId,
+      ReviewSort sort,
+      List<Long> designIds,
+      List<Style> styles,
+      ReviewCursor cursor,
+      int limit);
+
+  Set<Long> fetchLikedReviewIds(Long userId, List<Long> reviewIds);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,20 +1,31 @@
 package com.example.picknwhip_be.domain.review.repository;
 
 import com.example.picknwhip_be.domain.design.entity.QDesignGallery;
+import com.example.picknwhip_be.domain.design.enums.Style;
 import com.example.picknwhip_be.domain.order.entity.QOrder;
 import com.example.picknwhip_be.domain.review.dto.*;
 import com.example.picknwhip_be.domain.review.entity.QReview;
 import com.example.picknwhip_be.domain.review.entity.Review;
+import com.example.picknwhip_be.domain.review.entity.mapping.*;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewImage;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewKeyword;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewLike;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewReply;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewSelectedKeyword;
+import com.example.picknwhip_be.domain.review.enums.ReviewSort;
+import com.example.picknwhip_be.domain.review.service.query.cursor.ReviewCursor;
 import com.example.picknwhip_be.domain.shop.entity.QShop;
 import com.example.picknwhip_be.domain.user.entity.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
@@ -169,5 +180,152 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     Map<Long, Review> reviewMap = reviews.stream().collect(Collectors.toMap(Review::getId, r -> r));
 
     return ids.stream().map(reviewMap::get).toList();
+  }
+
+  @Override
+  public List<ReviewRow.ShopReviewRow> fetchShopReviewRows(
+      Long shopId,
+      ReviewSort sort,
+      List<Long> designIds,
+      List<Style> styles,
+      ReviewCursor cursor,
+      int limit) {
+    boolean hasDesignFilter = designIds != null && !designIds.isEmpty();
+    boolean hasStyleFilter = styles != null && !styles.isEmpty();
+    boolean hasAnyFilter = hasDesignFilter || hasStyleFilter;
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    where.and(review.shop.id.eq(shopId));
+    where.and(review.deletedAt.isNull());
+
+    if (hasAnyFilter) {
+      where.and(review.design.isNotNull());
+    }
+    if (hasDesignFilter) {
+      where.and(review.design.id.in(designIds));
+    }
+    if (hasStyleFilter) {
+      where.and(review.design.keywords.any().in(styles));
+    }
+
+    // 비집계 커서 조건은 WHERE에 적용
+    if (cursor != null && sort != ReviewSort.HELPFUL) {
+      where.and(applyCursor(sort, cursor));
+    }
+
+    NumberExpression<Long> likeCount = reviewLike.id.count();
+    OrderSpec orderSpec = orderSpec(sort, likeCount);
+
+    JPAQuery<ReviewRow.ShopReviewRow> query =
+        queryFactory
+            .select(
+                new QReviewRow_ShopReviewRow(
+                    review.id,
+                    user.nickname,
+                    user.profileImageUrl,
+                    review.rating,
+                    designGallery.designName,
+                    review.content,
+                    likeCount.intValue(),
+                    review.createdAt))
+            .from(review)
+            .join(review.user, user)
+            .leftJoin(review.design, designGallery)
+            .leftJoin(reviewLike)
+            .on(reviewLike.review.eq(review))
+            .where(where)
+            .groupBy(
+                review.id,
+                user.nickname,
+                user.profileImageUrl,
+                review.rating,
+                designGallery.designName,
+                review.content,
+                review.createdAt);
+
+    // HELPFUL 커서 조건은 집계값이므로 HAVING에 적용
+    if (cursor != null && sort == ReviewSort.HELPFUL) {
+      long helpful = cursor.primaryValue();
+      query.having(
+          likeCount.lt(helpful).or(likeCount.eq(helpful).and(review.id.lt(cursor.reviewId()))));
+    }
+
+    return query.orderBy(orderSpec.primary, orderSpec.tieBreaker).limit(limit).fetch();
+  }
+
+  @Override
+  public Set<Long> fetchLikedReviewIds(Long userId, List<Long> reviewIds) {
+    if (userId == null || reviewIds == null || reviewIds.isEmpty()) {
+      return Set.of();
+    }
+
+    QReviewLike reviewLike = QReviewLike.reviewLike;
+
+    List<Long> likedIds =
+        queryFactory
+            .select(reviewLike.review.id)
+            .from(reviewLike)
+            .where(reviewLike.user.userId.eq(userId), reviewLike.review.id.in(reviewIds))
+            .fetch();
+
+    return new HashSet<>(likedIds);
+  }
+
+  @Override
+  public List<ReviewRow.KeywordRow> fetchReviewKeywords(List<Long> reviewIds) {
+    if (reviewIds == null || reviewIds.isEmpty()) {
+      return List.of();
+    }
+
+    return queryFactory
+        .select(
+            new QReviewRow_KeywordRow(
+                reviewSelectedKeyword.review.id, reviewKeyword.code, reviewKeyword.label))
+        .from(reviewSelectedKeyword)
+        .join(reviewSelectedKeyword.keyword, reviewKeyword)
+        .where(reviewSelectedKeyword.review.id.in(reviewIds))
+        .orderBy(reviewSelectedKeyword.review.id.asc(), reviewKeyword.id.asc())
+        .fetch();
+  }
+
+  private record OrderSpec(OrderSpecifier<?> primary, OrderSpecifier<?> tieBreaker) {}
+
+  private OrderSpec orderSpec(ReviewSort sort, NumberExpression<Long> likeCount) {
+    return switch (sort) {
+      case LATEST -> new OrderSpec(review.createdAt.desc(), review.id.desc());
+      case HELPFUL -> new OrderSpec(likeCount.desc(), review.id.desc());
+      case RATING_HIGH -> new OrderSpec(review.rating.desc(), review.id.desc());
+      case RATING_LOW -> new OrderSpec(review.rating.asc(), review.id.asc());
+    };
+  }
+
+  /** 비집계 정렬(LATEST, RATING_HIGH, RATING_LOW)에 대한 커서 조건. HELPFUL은 having에서 처리. */
+  private BooleanExpression applyCursor(ReviewSort sort, ReviewCursor cursor) {
+    return switch (sort) {
+      case LATEST ->
+          review
+              .createdAt
+              .lt(cursor.createdAt())
+              .or(review.createdAt.eq(cursor.createdAt()).and(review.id.lt(cursor.reviewId())));
+
+      case RATING_HIGH -> {
+        int rating = cursor.primaryValue().intValue();
+        yield review
+            .rating
+            .lt(rating)
+            .or(review.rating.eq(rating).and(review.id.lt(cursor.reviewId())));
+      }
+
+      case RATING_LOW -> {
+        int rating = cursor.primaryValue().intValue();
+        yield review
+            .rating
+            .gt(rating)
+            .or(review.rating.eq(rating).and(review.id.gt(cursor.reviewId())));
+      }
+
+      case HELPFUL -> throw new IllegalStateException("HELPFUL cursor is handled via HAVING");
+    };
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
@@ -1,11 +1,15 @@
 package com.example.picknwhip_be.domain.review.service.query;
 
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 
 public interface ReviewQueryService {
   ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId);
 
   ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId);
+
+  ReviewResDTO.ShopReviewListDTO searchShopReviews(
+      Long shopId, ReviewReqDTO.ShopReviewListDTO dto, Long userId);
 
   ReviewResDTO.BestReviewListDTO getBestCustomReviews();
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -6,13 +6,22 @@ import com.example.picknwhip_be.domain.order.entity.OrderItem;
 import com.example.picknwhip_be.domain.order.repository.OrderItemRepository;
 import com.example.picknwhip_be.domain.review.converter.ReviewConverter;
 import com.example.picknwhip_be.domain.review.dto.ReviewRow;
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewSelectedKeyword;
+import com.example.picknwhip_be.domain.review.enums.ReviewSort;
+import com.example.picknwhip_be.domain.review.exception.ReviewException;
+import com.example.picknwhip_be.domain.review.exception.code.ReviewErrorCode;
 import com.example.picknwhip_be.domain.review.repository.ReviewLikeRepository;
 import com.example.picknwhip_be.domain.review.repository.ReviewRepository;
 import com.example.picknwhip_be.domain.review.repository.ReviewSelectedKeywordRepository;
+import com.example.picknwhip_be.domain.review.service.query.cursor.ReviewCursor;
+import com.example.picknwhip_be.domain.review.service.query.cursor.ReviewCursorCodec;
 import com.example.picknwhip_be.domain.shop.entity.enums.OptionCategory;
+import com.example.picknwhip_be.domain.shop.exception.ShopException;
+import com.example.picknwhip_be.domain.shop.exception.code.ShopErrorCode;
+import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -27,6 +36,8 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
   private final OrderItemRepository orderItemRepository;
   private final ReviewSelectedKeywordRepository reviewSelectedKeywordRepository;
   private final ReviewLikeRepository reviewLikeRepository;
+  private final ReviewCursorCodec cursorCodec;
+  private final ShopRepository shopRepository;
 
   @Override
   public ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId) {
@@ -60,6 +71,9 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
   @Override
   public ReviewResDTO.ReviewDetailDTO getReviewDetail(Long reviewId) {
     ReviewRow.ReviewDetailRow review = reviewRepository.fetchReviewDetail(reviewId);
+    if (review == null) {
+      throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
+    }
     List<ReviewRow.KeywordRow> keywordRows = reviewRepository.fetchReviewDetailKeywords(reviewId);
     List<ReviewRow.MyReviewImageRow> imageRows =
         reviewRepository.fetchMyReviewImages(List.of(reviewId));
@@ -78,6 +92,60 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
         review.nickname(),
         review.profileUrl(),
         keywords);
+  }
+
+  @Override
+  public ReviewResDTO.ShopReviewListDTO searchShopReviews(
+      Long shopId, ReviewReqDTO.ShopReviewListDTO dto, Long userId) {
+    if (!shopRepository.existsById(shopId)) {
+      throw new ShopException(ShopErrorCode.SHOP_NOT_FOUND);
+    }
+
+    ReviewSort sort = dto.sort() != null ? dto.sort() : ReviewSort.LATEST;
+    int size = dto.size() != null ? dto.size() : 20;
+
+    ReviewCursor cursor;
+    try {
+      cursor = cursorCodec.decode(sort, dto.cursor());
+    } catch (IllegalArgumentException e) {
+      throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
+    }
+
+    int limit = size + 1;
+
+    List<ReviewRow.ShopReviewRow> rows =
+        reviewRepository.fetchShopReviewRows(
+            shopId, sort, dto.designIds(), dto.styles(), cursor, limit);
+
+    boolean hasNext = rows.size() > size;
+    List<ReviewRow.ShopReviewRow> page = hasNext ? rows.subList(0, size) : rows;
+
+    String nextCursor = null;
+    if (hasNext && !page.isEmpty()) {
+      ReviewRow.ShopReviewRow last = page.getLast();
+      nextCursor = cursorCodec.encode(sort, ReviewCursor.fromRow(sort, last));
+    }
+
+    List<Long> reviewIds = page.stream().map(ReviewRow.ShopReviewRow::reviewId).toList();
+
+    // 배치 조회: 이미지, 키워드, 좋아요 여부
+    List<ReviewRow.MyReviewImageRow> imageRows = reviewRepository.fetchMyReviewImages(reviewIds);
+    Map<Long, List<String>> imageUrlsByReviewId = groupImageUrlsByReviewId(imageRows);
+
+    List<ReviewRow.KeywordRow> keywordRows = reviewRepository.fetchReviewKeywords(reviewIds);
+    Map<Long, List<ReviewResDTO.KeywordDTO>> keywordsByReviewId =
+        keywordRows.stream()
+            .collect(
+                Collectors.groupingBy(
+                    ReviewRow.KeywordRow::reviewId,
+                    Collectors.mapping(
+                        k -> new ReviewResDTO.KeywordDTO(k.code(), k.label()),
+                        Collectors.toList())));
+
+    Set<Long> likedReviewIds = reviewRepository.fetchLikedReviewIds(userId, reviewIds);
+
+    return ReviewConverter.toShopReviewListDTO(
+        page, imageUrlsByReviewId, keywordsByReviewId, likedReviewIds, nextCursor, hasNext);
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -23,6 +23,7 @@ import com.example.picknwhip_be.domain.shop.exception.ShopException;
 import com.example.picknwhip_be.domain.shop.exception.code.ShopErrorCode;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +54,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     Long nextCursor = null;
     if (hasNext && !pageRows.isEmpty()) {
-      nextCursor = pageRows.get(pageRows.size() - 1).reviewId();
+      nextCursor = pageRows.getLast().reviewId();
     }
 
     List<Long> reviewIds = pageRows.stream().map(ReviewRow.MyReviewRow::reviewId).toList();
@@ -107,7 +108,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     ReviewCursor cursor;
     try {
       cursor = cursorCodec.decode(sort, dto.cursor());
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | DateTimeParseException e) {
       throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
     }
 

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/cursor/ReviewCursor.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/cursor/ReviewCursor.java
@@ -1,0 +1,23 @@
+package com.example.picknwhip_be.domain.review.service.query.cursor;
+
+import com.example.picknwhip_be.domain.review.dto.ReviewRow;
+import com.example.picknwhip_be.domain.review.enums.ReviewSort;
+import java.time.LocalDateTime;
+
+public record ReviewCursor(Long primaryValue, LocalDateTime createdAt, Long reviewId) {
+  public static ReviewCursor forLatest(LocalDateTime createdAt, Long reviewId) {
+    return new ReviewCursor(null, createdAt, reviewId);
+  }
+
+  public static ReviewCursor forPrimary(long primaryValue, long reviewId) {
+    return new ReviewCursor(primaryValue, null, reviewId);
+  }
+
+  public static ReviewCursor fromRow(ReviewSort sort, ReviewRow.ShopReviewRow row) {
+    return switch (sort) {
+      case LATEST -> ReviewCursor.forLatest(row.createdDate(), row.reviewId());
+      case HELPFUL -> ReviewCursor.forPrimary(row.likeCount(), row.reviewId());
+      case RATING_HIGH, RATING_LOW -> ReviewCursor.forPrimary(row.rating(), row.reviewId());
+    };
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/cursor/ReviewCursorCodec.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/cursor/ReviewCursorCodec.java
@@ -1,0 +1,42 @@
+package com.example.picknwhip_be.domain.review.service.query.cursor;
+
+import com.example.picknwhip_be.domain.review.enums.ReviewSort;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReviewCursorCodec {
+
+  public String encode(ReviewSort sort, ReviewCursor cursor) {
+    if (cursor == null) return null;
+
+    String raw =
+        switch (sort) {
+          case LATEST -> cursor.createdAt() + "|" + cursor.reviewId();
+          case HELPFUL, RATING_HIGH, RATING_LOW -> cursor.primaryValue() + "|" + cursor.reviewId();
+        };
+
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public ReviewCursor decode(ReviewSort sort, String encoded) {
+    if (encoded == null || encoded.isBlank()) return null;
+
+    String raw = new String(Base64.getUrlDecoder().decode(encoded), StandardCharsets.UTF_8);
+    String[] parts = raw.split("\\|");
+    if (parts.length != 2) {
+      throw new IllegalArgumentException("Invalid cursor format");
+    }
+
+    return switch (sort) {
+      case LATEST ->
+          ReviewCursor.forLatest(LocalDateTime.parse(parts[0]), Long.parseLong(parts[1]));
+      case HELPFUL, RATING_HIGH, RATING_LOW ->
+          ReviewCursor.forPrimary(Long.parseLong(parts[0]), Long.parseLong(parts[1]));
+    };
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -1,5 +1,8 @@
 package com.example.picknwhip_be.domain.shop.controller;
 
+import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
+import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
+import com.example.picknwhip_be.domain.review.service.query.ReviewQueryService;
 import com.example.picknwhip_be.domain.shop.dto.ShopResDTO;
 import com.example.picknwhip_be.domain.shop.dto.res.ShopDetailResDTO;
 import com.example.picknwhip_be.domain.shop.dto.res.ShopPreviewResDTO;
@@ -11,19 +14,24 @@ import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/shops")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "Shop API", description = "가게 관련 API")
 public class ShopController {
 
   private final ShopService shopService;
   private final ShopQueryService shopQueryService;
+  private final ReviewQueryService reviewQueryService;
 
   @Operation(
       summary = "내 주변 가게 조회",
@@ -61,5 +69,17 @@ public class ShopController {
       @Parameter(description = "현재 위치 위도", required = true) @RequestParam double lat,
       @Parameter(description = "현재 위치 경도", required = true) @RequestParam double lon) {
     return ResponseEntity.ok(shopService.getShopDetail(shopId, lat, lon));
+  }
+
+  @Operation(
+      summary = "가게 리뷰 목록 조회 by 슝/하승연",
+      description = "가게 리뷰를 최신순/도움순/별점높은순/별점낮은순으로 정렬하여 조회하는 기능입니다.")
+  @GetMapping("/{shopId}/reviews")
+  public ApiResponse<ReviewResDTO.ShopReviewListDTO> getShopReviewList(
+      @PathVariable Long shopId,
+      @ParameterObject @Valid @ModelAttribute ReviewReqDTO.ShopReviewListDTO dto,
+      @Parameter(hidden = true) @ExtractPayload Long userId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewQueryService.searchShopReviews(shopId, dto, userId));
   }
 }

--- a/src/main/resources/db/seed/local/R__seed_local_design.sql
+++ b/src/main/resources/db/seed/local/R__seed_local_design.sql
@@ -61,7 +61,14 @@ insert into design_gallery (
     null,
     null,
     null
-);
+)
+AS new
+ON DUPLICATE KEY UPDATE
+    design_name = new.design_name,
+    base_price  = new.base_price,
+    image_url   = new.image_url;
+
+DELETE FROM design_gallery_keywords WHERE design_gallery_id IN (2, 3, 4);
 
 insert into design_gallery_keywords (
     design_gallery_id,

--- a/src/main/resources/db/seed/local/R__seed_local_design.sql
+++ b/src/main/resources/db/seed/local/R__seed_local_design.sql
@@ -1,0 +1,82 @@
+-- shop_cake_sizes가 R__seed_local_order.sql보다 먼저 실행되므로 여기서 선행 삽입
+INSERT INTO shop_cake_sizes (size_id, shop_id, size_name, diameter, price)
+VALUES (1, 1, '1호', '15cm', 30000) AS new
+ON DUPLICATE KEY UPDATE
+    shop_id   = new.shop_id,
+    size_name = new.size_name,
+    diameter  = new.diameter,
+    price     = new.price;
+
+insert into design_gallery (
+    id,
+    shop_id,
+    shop_cake_size_id,
+    design_name,
+    base_price,
+    image_url,
+    allergy_info,
+    description,
+    lettering_text,
+    lettering_line_count,
+    lettering_alignment
+) values
+-- 디자인 2
+(
+    2,
+    1,
+    1,
+    '미니멀 레터링 케이크',
+    35000,
+    'https://cdn.picknwhip.com/designs/minimal_lettering.jpg',
+    '우유, 계란, 밀',
+    '심플한 디자인의 미니멀 레터링 케이크입니다.',
+    'Happy Day',
+    'ONE_LINE',
+    'CENTER'
+),
+-- 디자인 3
+(
+    3,
+    1,
+    1,
+    '아이돌 포토 하트 케이크',
+    42000,
+    'https://cdn.picknwhip.com/designs/idol_photo_heart.jpg',
+    '우유, 계란',
+    '아이돌 사진이 올라간 하트 모양 케이크입니다.',
+    null,
+    null,
+    null
+),
+-- 디자인 4
+(
+    4,
+    1,
+    1,
+    '빈티지 생화 케이크',
+    45000,
+    'https://cdn.picknwhip.com/designs/vintage_flower.jpg',
+    '우유, 계란, 견과류',
+    '빈티지한 무드에 생화 장식이 들어간 케이크입니다.',
+    null,
+    null,
+    null
+);
+
+insert into design_gallery_keywords (
+    design_gallery_id,
+    keyword
+) values
+-- 디자인 2: 미니멀 + 원형 + 레터링
+(2, 'MINIMAL'),
+(2, 'ROUND'),
+(2, 'LETTERING'),
+
+-- 디자인 3: 아이돌 + 하트 + 포토케이크
+(3, 'IDOL'),
+(3, 'HEART'),
+(3, 'PHOTO_CAKE'),
+
+-- 디자인 4: 빈티지 + 심플
+(4, 'VINTAGE'),
+(4, 'SIMPLE');

--- a/src/main/resources/db/seed/local/R__seed_local_review.sql
+++ b/src/main/resources/db/seed/local/R__seed_local_review.sql
@@ -1,0 +1,244 @@
+-- ======================================================
+-- Local Review Seed Data (Repeatable)
+-- 가게 리뷰 목록 조회 테스트용
+-- shopId=1, userId=1 기준
+-- ======================================================
+
+-- ------------------------------------------------------
+-- 0) 테스트용 추가 유저 (좋아요 데이터용)
+-- ------------------------------------------------------
+INSERT INTO users (
+    user_id, created_at, updated_at, deleted_at,
+    email, kakao_id, name, nickname, birthdate, phone, profile_image_url, status
+) VALUES
+(3, NOW(6), NOW(6), NULL, 'local.tester2@picknwhip.com', 2000000002, '테스터2', '딸기케이크', NULL, '010-2222-2222', NULL, 'ACTIVE'),
+(4, NOW(6), NOW(6), NULL, 'local.tester3@picknwhip.com', 2000000003, '테스터3', '바닐라케이크', NULL, '010-3333-3333', NULL, 'ACTIVE'),
+(5, NOW(6), NOW(6), NULL, 'local.tester4@picknwhip.com', 2000000004, '테스터4', '당근케이크', NULL, '010-4444-4444', NULL, 'ACTIVE')
+AS new
+ON DUPLICATE KEY UPDATE updated_at = new.updated_at, status = new.status;
+
+-- ------------------------------------------------------
+-- 1) 추가 주문 데이터 (order id 2~8)
+--    design_id: 1~4 갤러리 디자인 + NULL(커스텀)
+-- ------------------------------------------------------
+INSERT INTO orders (
+    id, user_id, shop_id, shop_cake_size_id, design_id,
+    status, pickup_datetime,
+    lettering_text, lettering_line_count, lettering_alignment,
+    additional_request, order_additional_request,
+    reference_image_url, payment_method, payment_status,
+    total_price, deposit_amount, rejection_reason,
+    created_at, updated_at,
+    order_code, customer_name, customer_phone
+) VALUES
+-- 주문 2: 디자인 2 (미니멀 레터링)
+(2, 1, 1, 1, 2,
+ 'COMPLETED', '2026-01-10 14:00:00',
+ '사랑해', 'ONE_LINE', 'CENTER',
+ NULL, NULL,
+ NULL, 'CARD', 'PAID',
+ 35000, 10000, NULL,
+ '2026-01-08 10:00:00', '2026-01-08 10:00:00',
+ '260110_001', '김픽휩', '010-1234-5678'),
+
+-- 주문 3: 디자인 3 (아이돌 포토 하트)
+(3, 1, 1, 1, 3,
+ 'COMPLETED', '2026-01-15 16:00:00',
+ NULL, NULL, NULL,
+ '포토카드 2장 넣어주세요', NULL,
+ NULL, 'CARD', 'PAID',
+ 42000, 15000, NULL,
+ '2026-01-13 09:00:00', '2026-01-13 09:00:00',
+ '260115_001', '김픽휩', '010-1234-5678'),
+
+-- 주문 4: 디자인 4 (빈티지 생화)
+(4, 1, 1, 1, 4,
+ 'COMPLETED', '2026-01-18 13:00:00',
+ NULL, NULL, NULL,
+ '장미 위주로 올려주세요', NULL,
+ NULL, 'CARD', 'PAID',
+ 45000, 15000, NULL,
+ '2026-01-16 11:00:00', '2026-01-16 11:00:00',
+ '260118_001', '김픽휩', '010-1234-5678'),
+
+-- 주문 5: 디자인 1 (심플 플라워) 재주문
+(5, 1, 1, 1, 1,
+ 'COMPLETED', '2026-01-22 15:00:00',
+ '축하해', 'ONE_LINE', 'CENTER',
+ '이번엔 핑크 장미로 해주세요', NULL,
+ NULL, 'CARD', 'PAID',
+ 35000, 10000, NULL,
+ '2026-01-20 14:00:00', '2026-01-20 14:00:00',
+ '260122_001', '김픽휩', '010-1234-5678'),
+
+-- 주문 6: 커스텀 디자인 (design_id = NULL)
+(6, 1, 1, 1, NULL,
+ 'COMPLETED', '2026-01-25 11:00:00',
+ '우리 1주년', 'ONE_LINE', 'CENTER',
+ '하트 모양 케이크에 핑크 아이싱 부탁드려요', NULL,
+ 'https://example.com/reference/custom1.jpg', 'CARD', 'PAID',
+ 50000, 20000, NULL,
+ '2026-01-23 08:00:00', '2026-01-23 08:00:00',
+ '260125_001', '김픽휩', '010-1234-5678'),
+
+-- 주문 7: 커스텀 디자인 (design_id = NULL)
+(7, 1, 1, 1, NULL,
+ 'COMPLETED', '2026-01-28 17:00:00',
+ NULL, NULL, NULL,
+ '강아지 얼굴 그려주세요', NULL,
+ 'https://example.com/reference/custom2.jpg', 'CARD', 'PAID',
+ 55000, 20000, NULL,
+ '2026-01-26 16:00:00', '2026-01-26 16:00:00',
+ '260128_001', '김픽휩', '010-1234-5678'),
+
+-- 주문 8: 디자인 2 (미니멀 레터링) 재주문
+(8, 1, 1, 1, 2,
+ 'COMPLETED', '2026-02-01 12:00:00',
+ '졸업 축하해', 'ONE_LINE', 'CENTER',
+ NULL, NULL,
+ NULL, 'CARD', 'PAID',
+ 35000, 10000, NULL,
+ '2026-01-30 10:00:00', '2026-01-30 10:00:00',
+ '260201_001', '김픽휩', '010-1234-5678')
+
+AS new
+ON DUPLICATE KEY UPDATE
+    user_id = new.user_id,
+    shop_id = new.shop_id,
+    design_id = new.design_id,
+    status = new.status,
+    updated_at = NOW();
+
+
+-- ------------------------------------------------------
+-- 2) 리뷰 데이터 (review id 1~8)
+--    다양한 별점, 날짜 (좋아요 수는 review_like로 결정)
+-- ------------------------------------------------------
+INSERT INTO review (
+    id, order_id, user_id, shop_id, design_id,
+    rating, content, agreement,
+    deleted_at, created_at, updated_at
+) VALUES
+-- 리뷰 1: 주문1, 디자인1, 별점5
+(1, 1, 1, 1, 1,
+ 5, '심플 플라워 디자인 너무 예뻤어요! 생일파티에서 모두가 감탄했습니다. 딸기도 많이 올려주셔서 맛도 좋았어요.',
+ true,
+ NULL, '2026-01-05 10:00:00', '2026-01-05 10:00:00'),
+
+-- 리뷰 2: 주문2, 디자인2, 별점4
+(2, 2, 1, 1, 2,
+ 4, '미니멀 레터링이 깔끔하고 좋았어요. 다만 크림이 조금 달았으면 더 좋았을 것 같아요. 전체적으로 만족합니다!',
+ true,
+ NULL, '2026-01-12 09:00:00', '2026-01-12 09:00:00'),
+
+-- 리뷰 3: 주문3, 디자인3, 별점5
+(3, 3, 1, 1, 3,
+ 5, '아이돌 포토 케이크 퀄리티가 정말 높아요! 포토카드도 예쁘게 넣어주셨고 하트 모양도 완벽했습니다. 최애 생일에 딱이에요!',
+ true,
+ NULL, '2026-01-17 14:00:00', '2026-01-17 14:00:00'),
+
+-- 리뷰 4: 주문4, 디자인4, 별점3
+(4, 4, 1, 1, 4,
+ 3, '빈티지 분위기는 좋았는데 생화가 생각보다 빨리 시들었어요. 케이크 맛 자체는 괜찮았습니다. 다음엔 조화로 해달라고 할게요.',
+ true,
+ NULL, '2026-01-20 11:00:00', '2026-01-20 11:00:00'),
+
+-- 리뷰 5: 주문5, 디자인1, 별점5
+(5, 5, 1, 1, 1,
+ 5, '재주문했는데 역시 실망시키지 않네요! 핑크 장미로 바꿔주셨는데 더 예뻐요. 사장님이 항상 친절하세요.',
+ true,
+ NULL, '2026-01-24 16:00:00', '2026-01-24 16:00:00'),
+
+-- 리뷰 6: 주문6, 커스텀(NULL), 별점4
+(6, 6, 1, 1, NULL,
+ 4, '커스텀 주문이라 걱정했는데 레퍼런스 사진보다 더 예쁘게 만들어주셨어요! 핑크 아이싱 색감이 정말 좋았습니다.',
+ true,
+ NULL, '2026-01-27 13:00:00', '2026-01-27 13:00:00'),
+
+-- 리뷰 7: 주문7, 커스텀(NULL), 별점2
+(7, 7, 1, 1, NULL,
+ 2, '강아지 얼굴이 레퍼런스와 좀 달랐어요. 맛은 괜찮았지만 디자인이 기대에 못 미쳤습니다. 조금 아쉬워요.',
+ true,
+ NULL, '2026-01-30 18:00:00', '2026-01-30 18:00:00'),
+
+-- 리뷰 8: 주문8, 디자인2, 별점5
+(8, 8, 1, 1, 2,
+ 5, '졸업 선물로 주문했는데 레터링이 너무 예쁘게 나왔어요! 받는 사람이 정말 좋아했습니다. 미니멀한 디자인 최고!',
+ true,
+ NULL, '2026-02-02 09:00:00', '2026-02-02 09:00:00')
+
+AS new
+ON DUPLICATE KEY UPDATE
+    rating = new.rating,
+    content = new.content,
+    updated_at = NOW();
+
+
+-- ------------------------------------------------------
+-- 3) 리뷰 키워드 매핑
+--    review_keyword id는 V5 INSERT 순서 기준:
+--    1=MATCH_REQUEST, 2=PRETTY, 3=CREATIVE, 4=SPECIAL, 5=LUXURIOUS
+--    6=SAME_AS_PHOTO, 7=BEYOND_EXPECTATION, 8=ACCURATE, 9=BETTER
+--    10=DELICIOUS, 11=FRESH, 12=SWEET, 13=MOIST, 14=NOT_TOO_SWEET
+--    15=KIND, 16=DETAILED, 17=FAST_RESPONSE, 18=GOOD_LISTENER, 19=EASY
+--    20=EASY_PICKUP, 21=CLEAN, 22=ON_TIME
+-- ------------------------------------------------------
+DELETE FROM review_selected_keyword WHERE review_id IN (1,2,3,4,5,6,7,8);
+
+INSERT INTO review_selected_keyword (review_id, keyword_id) VALUES
+-- 리뷰 1: 예뻐요, 맛있어요, 요청사항 잘 들어줘요
+(1, 2), (1, 10), (1, 18),
+
+-- 리뷰 2: 디자인 예뻐요, 친절해요
+(2, 2), (2, 15),
+
+-- 리뷰 3: 원하는 디자인 잘해줬어요, 사진과 똑같아요, 기대 이상, 친절해요, 픽업 편해요
+(3, 1), (3, 6), (3, 7), (3, 15), (3, 20),
+
+-- 리뷰 4: 맛있어요
+(4, 10),
+
+-- 리뷰 5: 예뻐요, 친절해요, 요청사항 잘 들어줘요, 시간 잘 지켜요
+(5, 2), (5, 15), (5, 18), (5, 22),
+
+-- 리뷰 6: 기대 이상이에요, 창의적이에요, 소통이 편해요
+(6, 7), (6, 3), (6, 19),
+
+-- 리뷰 7: (키워드 없음 - 낮은 별점)
+
+-- 리뷰 8: 예뻐요, 정확해요, 매장 깨끗해요
+(8, 2), (8, 8), (8, 21);
+
+
+-- ------------------------------------------------------
+-- 4) 리뷰 좋아요 (review_like)
+--    좋아요 수로 도움순(HELPFUL) 정렬 테스트
+--    리뷰3: 4개, 리뷰5: 3개, 리뷰1: 2개, 리뷰2: 1개, 리뷰6: 1개, 리뷰8: 1개
+--    리뷰4: 0개, 리뷰7: 0개
+-- ------------------------------------------------------
+DELETE FROM review_like WHERE review_id IN (1,2,3,4,5,6,7,8);
+
+INSERT INTO review_like (review_id, user_id, created_at, updated_at) VALUES
+-- 리뷰 3: 좋아요 4개 (userId 1,3,4,5)
+(3, 1, NOW(6), NOW(6)),
+(3, 3, NOW(6), NOW(6)),
+(3, 4, NOW(6), NOW(6)),
+(3, 5, NOW(6), NOW(6)),
+
+-- 리뷰 5: 좋아요 3개 (userId 1,3,4)
+(5, 1, NOW(6), NOW(6)),
+(5, 3, NOW(6), NOW(6)),
+(5, 4, NOW(6), NOW(6)),
+
+-- 리뷰 1: 좋아요 2개 (userId 3,4)
+(1, 3, NOW(6), NOW(6)),
+(1, 4, NOW(6), NOW(6)),
+
+-- 리뷰 2: 좋아요 1개 (userId 3)
+(2, 3, NOW(6), NOW(6)),
+
+-- 리뷰 6: 좋아요 1개 (userId 4)
+(6, 4, NOW(6), NOW(6)),
+
+-- 리뷰 8: 좋아요 1개 (userId 5)
+(8, 5, NOW(6), NOW(6));


### PR DESCRIPTION
## 💡 Issue
- Close #129 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 가게별 리뷰를 정렬 4가지 옵션(최신순/도움순/별점낮은순/별점높은순)과, 2종류의 필터(디자인 갤러리, 스타일)를 적용해 커서 기반 페이지네이션으로 조회하는 API를 구현하였습니다. ~솔직히 너무 힘들었어요...~
- 엔드포인트가 shops의 reviews로 가는 게 자연스러울 것 같아 리뷰 조회지만 컨트롤러를 ShopController에 작성하였습니다.
- 필터를 적용할 때 가게가 디자인 갤러리에 등록한 디자인에 있는 스타일 키워드를 사용하는데, 찾아 보니 현재 디자인 갤러리에서 스타일 키워드를 저장할 때 String으로 받고 있어서 Style enum 파일을 만들고 관련 참조 코드들을 리팩터링했습니다.
- 필터에서 디자인 갤러리의 디자인 이름을 보고 고를 수 있게 해야 돼서 이름 조회 API를 따로 만들어야할 것 같습니다..
- 리뷰 조회가 너무 복잡해서 가게 리뷰 상단에 뜨는 요약(리뷰 개수, 평균 별점, 키워드 순위)도 API를 따로 분리해 구현하려고 합니다.

## 🛠️ Changes
- Style enum 파일 작성
- 디자인 갤러리의 키워드를 String에서 enum으로 변경
- 반영한 seed 추가
- ShopController에 API 추가
- 정렬 4가지 선택 및 필터를 쿼리 스트링으로 보낼 수 있도록 구현
- 커서 값을 리뷰 ID와 정렬 관련 값을 합쳐 복합 커서로 구현
- 테스트를 위한 seed 데이터 작성
- .gitignore에 클로드 추가

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?