### PR TITLE
[FEAT/#145] 가게 리뷰 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -88,14 +88,4 @@ public class ReviewController {
   public ApiResponse<ReviewResDTO.ReviewDetailDTO> getReviewDetail(@PathVariable Long reviewId) {
     return ApiResponse.of(GeneralSuccessCode.OK, reviewQueryService.getReviewDetail(reviewId));
   }
-
-  @Operation(
-      summary = "가게 리뷰 통계 조회 by 슝/하승연",
-      description = "가게 리뷰 상단에서 평균 별점과 리뷰 개수, 키워드별 순위를 조회하는 기능입니다. ")
-  @GetMapping("/{shopId}/summary")
-  public ApiResponse<ReviewResDTO.ShopReviewSummaryDTO> getShopReviewSummary(
-      @PathVariable Long shopId) {
-    return ApiResponse.of(
-        GeneralSuccessCode.OK, reviewQueryService.searchShopReviewSummary(shopId));
-  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/controller/ReviewController.java
@@ -88,4 +88,14 @@ public class ReviewController {
   public ApiResponse<ReviewResDTO.ReviewDetailDTO> getReviewDetail(@PathVariable Long reviewId) {
     return ApiResponse.of(GeneralSuccessCode.OK, reviewQueryService.getReviewDetail(reviewId));
   }
+
+  @Operation(
+      summary = "가게 리뷰 통계 조회 by 슝/하승연",
+      description = "가게 리뷰 상단에서 평균 별점과 리뷰 개수, 키워드별 순위를 조회하는 기능입니다. ")
+  @GetMapping("/{shopId}/summary")
+  public ApiResponse<ReviewResDTO.ShopReviewSummaryDTO> getShopReviewSummary(
+      @PathVariable Long shopId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewQueryService.searchShopReviewSummary(shopId));
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -6,12 +6,14 @@ import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.entity.Review;
 import com.example.picknwhip_be.domain.review.entity.mapping.ReviewLike;
+import com.example.picknwhip_be.domain.review.enums.KeywordCategory;
 import com.example.picknwhip_be.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ReviewConverter {
   public static ReviewResDTO.WriteDTO toWriteDTO(Long reviewId) {
@@ -135,6 +137,32 @@ public class ReviewConverter {
         .items(items)
         .nextCursor(nextCursor)
         .hasNext(hasNext)
+        .build();
+  }
+
+  public static ReviewResDTO.ShopReviewSummaryDTO toShopReviewSummaryDTO(
+      double rating, int count, List<ReviewRow.KeywordCategoryCountRow> categoryCounts) {
+    Map<KeywordCategory, Long> countMap =
+        categoryCounts.stream()
+            .collect(
+                Collectors.toMap(
+                    ReviewRow.KeywordCategoryCountRow::category,
+                    ReviewRow.KeywordCategoryCountRow::count));
+
+    ReviewResDTO.KeywordRankingDTO keywordRankingDTO =
+        ReviewResDTO.KeywordRankingDTO.builder()
+            .DESIGN_SATISFACTION(
+                countMap.getOrDefault(KeywordCategory.DESIGN_SATISFACTION, 0L).intValue())
+            .SAME_AS_RESULT(countMap.getOrDefault(KeywordCategory.SAME_AS_RESULT, 0L).intValue())
+            .TASTE(countMap.getOrDefault(KeywordCategory.TASTE, 0L).intValue())
+            .COMMUNICATION(countMap.getOrDefault(KeywordCategory.COMMUNICATION, 0L).intValue())
+            .PICKUP(countMap.getOrDefault(KeywordCategory.PICKUP, 0L).intValue())
+            .build();
+
+    return ReviewResDTO.ShopReviewSummaryDTO.builder()
+        .rating(rating)
+        .count(count)
+        .keywordRanking(List.of(keywordRankingDTO))
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/converter/ReviewConverter.java
@@ -151,18 +151,18 @@ public class ReviewConverter {
 
     ReviewResDTO.KeywordRankingDTO keywordRankingDTO =
         ReviewResDTO.KeywordRankingDTO.builder()
-            .DESIGN_SATISFACTION(
+            .designSatisfaction(
                 countMap.getOrDefault(KeywordCategory.DESIGN_SATISFACTION, 0L).intValue())
-            .SAME_AS_RESULT(countMap.getOrDefault(KeywordCategory.SAME_AS_RESULT, 0L).intValue())
-            .TASTE(countMap.getOrDefault(KeywordCategory.TASTE, 0L).intValue())
-            .COMMUNICATION(countMap.getOrDefault(KeywordCategory.COMMUNICATION, 0L).intValue())
-            .PICKUP(countMap.getOrDefault(KeywordCategory.PICKUP, 0L).intValue())
+            .sameAsResult(countMap.getOrDefault(KeywordCategory.SAME_AS_RESULT, 0L).intValue())
+            .taste(countMap.getOrDefault(KeywordCategory.TASTE, 0L).intValue())
+            .communication(countMap.getOrDefault(KeywordCategory.COMMUNICATION, 0L).intValue())
+            .pickup(countMap.getOrDefault(KeywordCategory.PICKUP, 0L).intValue())
             .build();
 
     return ReviewResDTO.ShopReviewSummaryDTO.builder()
         .rating(rating)
         .count(count)
-        .keywordRanking(List.of(keywordRankingDTO))
+        .keywordRanking(keywordRankingDTO)
         .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/ReviewRow.java
@@ -1,5 +1,6 @@
 package com.example.picknwhip_be.domain.review.dto;
 
+import com.example.picknwhip_be.domain.review.enums.KeywordCategory;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 
@@ -26,9 +27,9 @@ public class ReviewRow {
     public MyReviewReplyRow {}
   }
 
-  public record MyReviewSummaryRow(long count, Double averageRating) {
+  public record ReviewSummaryRow(long count, Double averageRating) {
     @QueryProjection
-    public MyReviewSummaryRow {}
+    public ReviewSummaryRow {}
   }
 
   public record ReviewDetailRow(
@@ -59,5 +60,10 @@ public class ReviewRow {
       LocalDateTime createdDate) {
     @QueryProjection
     public ShopReviewRow {}
+  }
+
+  public record KeywordCategoryCountRow(KeywordCategory category, long count) {
+    @QueryProjection
+    public KeywordCategoryCountRow {}
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -94,15 +94,15 @@ public class ReviewResDTO {
   public record ShopReviewSummaryDTO(
       @Schema(description = "평균 별점", example = "4.8") double rating,
       @Schema(description = "리뷰 개수", example = "342") int count,
-      @Schema(description = "키워드 순위") List<KeywordRankingDTO> keywordRanking) {}
+      @Schema(description = "키워드 순위") KeywordRankingDTO keywordRanking) {}
 
   @Builder
   public record KeywordRankingDTO(
-      @Schema(description = "디자인만족", example = "50") int DESIGN_SATISFACTION,
-      @Schema(description = "결과물통일", example = "35") int SAME_AS_RESULT,
-      @Schema(description = "맛", example = "28") int TASTE,
-      @Schema(description = "소통", example = "17") int COMMUNICATION,
-      @Schema(description = "픽업진행", example = "3") int PICKUP) {}
+      @Schema(description = "디자인만족", example = "50") int designSatisfaction,
+      @Schema(description = "결과물통일", example = "35") int sameAsResult,
+      @Schema(description = "맛", example = "28") int taste,
+      @Schema(description = "소통", example = "17") int communication,
+      @Schema(description = "픽업진행", example = "3") int pickup) {}
 
   // 홈화면 - 베스트 커스텀 옵션 리뷰 조회 DTO
   @Builder

--- a/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/dto/res/ReviewResDTO.java
@@ -90,6 +90,20 @@ public class ReviewResDTO {
           @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
           LocalDateTime createdDate) {}
 
+  @Builder
+  public record ShopReviewSummaryDTO(
+      @Schema(description = "평균 별점", example = "4.8") double rating,
+      @Schema(description = "리뷰 개수", example = "342") int count,
+      @Schema(description = "키워드 순위") List<KeywordRankingDTO> keywordRanking) {}
+
+  @Builder
+  public record KeywordRankingDTO(
+      @Schema(description = "디자인만족", example = "50") int DESIGN_SATISFACTION,
+      @Schema(description = "결과물통일", example = "35") int SAME_AS_RESULT,
+      @Schema(description = "맛", example = "28") int TASTE,
+      @Schema(description = "소통", example = "17") int COMMUNICATION,
+      @Schema(description = "픽업진행", example = "3") int PICKUP) {}
+
   // 홈화면 - 베스트 커스텀 옵션 리뷰 조회 DTO
   @Builder
   public record BestReviewListDTO(

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryCustom.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 public interface ReviewRepositoryCustom {
-  ReviewRow.MyReviewSummaryRow fetchMyReviewSummary(Long userId);
+  ReviewRow.ReviewSummaryRow fetchMyReviewSummary(Long userId);
 
   List<ReviewRow.MyReviewRow> fetchMyReviews(Long userId, Long cursor, int limit);
 
@@ -34,4 +34,8 @@ public interface ReviewRepositoryCustom {
       int limit);
 
   Set<Long> fetchLikedReviewIds(Long userId, List<Long> reviewIds);
+
+  ReviewRow.ReviewSummaryRow fetchShopReviewSummary(Long shopId);
+
+  List<ReviewRow.KeywordCategoryCountRow> fetchShopKeywordCategoryCounts(Long shopId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.example.picknwhip_be.domain.order.entity.QOrder;
 import com.example.picknwhip_be.domain.review.dto.*;
 import com.example.picknwhip_be.domain.review.entity.QReview;
 import com.example.picknwhip_be.domain.review.entity.Review;
-import com.example.picknwhip_be.domain.review.entity.mapping.*;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewImage;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewKeyword;
 import com.example.picknwhip_be.domain.review.entity.mapping.QReviewLike;
@@ -46,7 +45,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
       QReviewSelectedKeyword.reviewSelectedKeyword;
 
   @Override
-  public ReviewRow.MyReviewSummaryRow fetchMyReviewSummary(Long userId) {
+  public ReviewRow.ReviewSummaryRow fetchMyReviewSummary(Long userId) {
     return queryFactory
         .select(new QReviewRow_MyReviewSummaryRow(review.id.count(), review.rating.avg()))
         .from(review)
@@ -298,6 +297,29 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
       case RATING_HIGH -> new OrderSpec(review.rating.desc(), review.id.desc());
       case RATING_LOW -> new OrderSpec(review.rating.asc(), review.id.asc());
     };
+  }
+
+  @Override
+  public ReviewRow.ReviewSummaryRow fetchShopReviewSummary(Long shopId) {
+    return queryFactory
+        .select(new QReviewRow_MyReviewSummaryRow(review.id.count(), review.rating.avg()))
+        .from(review)
+        .where(review.shop.id.eq(shopId), review.deletedAt.isNull())
+        .fetchOne();
+  }
+
+  @Override
+  public List<ReviewRow.KeywordCategoryCountRow> fetchShopKeywordCategoryCounts(Long shopId) {
+    return queryFactory
+        .select(
+            new QReviewRow_KeywordCategoryCountRow(
+                reviewKeyword.category, reviewSelectedKeyword.id.count()))
+        .from(reviewSelectedKeyword)
+        .join(reviewSelectedKeyword.keyword, reviewKeyword)
+        .join(reviewSelectedKeyword.review, review)
+        .where(review.shop.id.eq(shopId), review.deletedAt.isNull())
+        .groupBy(reviewKeyword.category)
+        .fetch();
   }
 
   /** 비집계 정렬(LATEST, RATING_HIGH, RATING_LOW)에 대한 커서 조건. HELPFUL은 having에서 처리. */

--- a/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/repository/ReviewRepositoryImpl.java
@@ -47,7 +47,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
   @Override
   public ReviewRow.ReviewSummaryRow fetchMyReviewSummary(Long userId) {
     return queryFactory
-        .select(new QReviewRow_MyReviewSummaryRow(review.id.count(), review.rating.avg()))
+        .select(new QReviewRow_ReviewSummaryRow(review.id.count(), review.rating.avg()))
         .from(review)
         .where(review.user.userId.eq(userId), review.deletedAt.isNull())
         .fetchOne();
@@ -302,7 +302,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
   @Override
   public ReviewRow.ReviewSummaryRow fetchShopReviewSummary(Long shopId) {
     return queryFactory
-        .select(new QReviewRow_MyReviewSummaryRow(review.id.count(), review.rating.avg()))
+        .select(new QReviewRow_ReviewSummaryRow(review.id.count(), review.rating.avg()))
         .from(review)
         .where(review.shop.id.eq(shopId), review.deletedAt.isNull())
         .fetchOne();

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryService.java
@@ -11,5 +11,7 @@ public interface ReviewQueryService {
   ReviewResDTO.ShopReviewListDTO searchShopReviews(
       Long shopId, ReviewReqDTO.ShopReviewListDTO dto, Long userId);
 
+  ReviewResDTO.ShopReviewSummaryDTO searchShopReviewSummary(Long shopId);
+
   ReviewResDTO.BestReviewListDTO getBestCustomReviews();
 }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -156,11 +156,13 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     }
 
     ReviewRow.ReviewSummaryRow summary = reviewRepository.fetchShopReviewSummary(shopId);
-    double rating = roundTo1Decimal(summary == null ? null : summary.averageRating());
-    int count = summary == null ? 0 : (int) summary.count();
+    double rating = roundTo1Decimal(summary.averageRating());
+    int count = (int) summary.count();
 
-    List<ReviewRow.KeywordCategoryCountRow> categoryCounts =
-        reviewRepository.fetchShopKeywordCategoryCounts(shopId);
+    List<ReviewRow.KeywordCategoryCountRow> categoryCounts = Collections.emptyList();
+    if (count > 0) {
+      categoryCounts = reviewRepository.fetchShopKeywordCategoryCounts(shopId);
+    }
 
     return ReviewConverter.toShopReviewSummaryDTO(rating, count, categoryCounts);
   }

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -156,8 +156,8 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     }
 
     ReviewRow.ReviewSummaryRow summary = reviewRepository.fetchShopReviewSummary(shopId);
-    double rating = roundTo1Decimal(summary.averageRating());
-    int count = (int) summary.count();
+    double rating = roundTo1Decimal(summary == null ? null : summary.averageRating());
+    int count = summary == null ? 0 : (int) summary.count();
 
     List<ReviewRow.KeywordCategoryCountRow> categoryCounts = Collections.emptyList();
     if (count > 0) {

--- a/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -42,7 +42,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
   @Override
   public ReviewResDTO.MyReviewListDTO getMyReviewList(Long cursor, int size, Long userId) {
-    ReviewRow.MyReviewSummaryRow summary = reviewRepository.fetchMyReviewSummary(userId);
+    ReviewRow.ReviewSummaryRow summary = reviewRepository.fetchMyReviewSummary(userId);
     long count = (summary == null) ? 0L : summary.count();
     double avgRating = roundTo1Decimal(summary == null ? null : summary.averageRating());
 
@@ -147,6 +147,22 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     return ReviewConverter.toShopReviewListDTO(
         page, imageUrlsByReviewId, keywordsByReviewId, likedReviewIds, nextCursor, hasNext);
+  }
+
+  @Override
+  public ReviewResDTO.ShopReviewSummaryDTO searchShopReviewSummary(Long shopId) {
+    if (!shopRepository.existsById(shopId)) {
+      throw new ShopException(ShopErrorCode.SHOP_NOT_FOUND);
+    }
+
+    ReviewRow.ReviewSummaryRow summary = reviewRepository.fetchShopReviewSummary(shopId);
+    double rating = roundTo1Decimal(summary == null ? null : summary.averageRating());
+    int count = summary == null ? 0 : (int) summary.count();
+
+    List<ReviewRow.KeywordCategoryCountRow> categoryCounts =
+        reviewRepository.fetchShopKeywordCategoryCounts(shopId);
+
+    return ReviewConverter.toShopReviewSummaryDTO(rating, count, categoryCounts);
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -82,4 +82,14 @@ public class ShopController {
     return ApiResponse.of(
         GeneralSuccessCode.OK, reviewQueryService.searchShopReviews(shopId, dto, userId));
   }
+
+  @Operation(
+      summary = "가게 리뷰 통계 조회 by 슝/하승연",
+      description = "가게 리뷰 상단에서 평균 별점과 리뷰 개수, 키워드별 순위를 조회하는 기능입니다. ")
+  @GetMapping("/{shopId}/reviews/summary")
+  public ApiResponse<ReviewResDTO.ShopReviewSummaryDTO> getShopReviewSummary(
+      @PathVariable Long shopId) {
+    return ApiResponse.of(
+        GeneralSuccessCode.OK, reviewQueryService.searchShopReviewSummary(shopId));
+  }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #145 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 특이사항 없음

## 🛠️ Changes
- 가게별 리뷰 평균 별점, 리뷰 개수, 키워드 카테고리별 리뷰 개수 제공
- QueryDSL로 조회 후 서비스에서 정리하여 컨버터로 전달하도록 구현
- 범용 사용을 위해 MyReviewSummaryRow에서 My 삭제

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?