### PR TITLE
[FEAT/#146] 가게 리뷰 필터 디자인 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
@@ -65,4 +65,9 @@ public class DesignConverter {
         .options(options)
         .build();
   }
+
+  public static DesignResDTO.DesignListDTO toShopDesignNameListDTO(
+      List<DesignResDTO.DesignNameDTO> items) {
+    return DesignResDTO.DesignListDTO.builder().items(items).build();
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/design/dto/res/DesignResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/dto/res/DesignResDTO.java
@@ -3,6 +3,7 @@ package com.example.picknwhip_be.domain.design.dto.res;
 import com.example.picknwhip_be.domain.custom.dto.res.CustomResDTO;
 import com.example.picknwhip_be.domain.order.entity.enums.LetteringAlignment;
 import com.example.picknwhip_be.domain.order.entity.enums.LetteringLineCount;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,4 +50,12 @@ public class DesignResDTO {
     private List<CustomResDTO.Topping> toppings;
     private List<CustomResDTO.Option> options;
   }
+
+  @Builder
+  public record DesignNameDTO(
+      @Schema(description = "디자인 ID", example = "1") Long designId,
+      @Schema(description = "디자인 이름", example = "크리스마스 케이크") String designName) {}
+
+  @Builder
+  public record DesignListDTO(@Schema(description = "디자인 목록") List<DesignNameDTO> items) {}
 }

--- a/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepository.java
@@ -6,7 +6,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DesignGalleryRepository extends JpaRepository<DesignGallery, Long> {
+public interface DesignGalleryRepository
+    extends JpaRepository<DesignGallery, Long>, DesignGalleryRepositoryCustom {
 
   @EntityGraph(attributePaths = {"options", "options.customOption", "shopCakeSize", "keywords"})
   Optional<DesignGallery> findDesignGalleryById(Long id);

--- a/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepositoryCustom.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.example.picknwhip_be.domain.design.repository;
+
+import com.example.picknwhip_be.domain.design.dto.res.DesignResDTO;
+import java.util.List;
+
+public interface DesignGalleryRepositoryCustom {
+  List<DesignResDTO.DesignNameDTO> fetchDesignNamesByShopId(Long shopId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepositoryImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.example.picknwhip_be.domain.design.repository;
+
+import com.example.picknwhip_be.domain.design.dto.res.DesignResDTO;
+import com.example.picknwhip_be.domain.design.entity.QDesignGallery;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DesignGalleryRepositoryImpl implements DesignGalleryRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<DesignResDTO.DesignNameDTO> fetchDesignNamesByShopId(Long shopId) {
+    QDesignGallery designGallery = QDesignGallery.designGallery;
+    return queryFactory
+        .select(
+            Projections.constructor(
+                DesignResDTO.DesignNameDTO.class, designGallery.id, designGallery.designName))
+        .from(designGallery)
+        .where(designGallery.shop.id.eq(shopId))
+        .fetch();
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryService.java
@@ -9,4 +9,6 @@ public interface DesignQueryService {
   DesignResDTO.GetDesignListDTO findDesignListByShopId(Long shopId);
 
   DesignResDTO.GetDesignDetailDTO findDesignDetail(Long designId);
+
+  DesignResDTO.DesignListDTO findShopDesignNameList(Long shopId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryServiceImpl.java
@@ -67,19 +67,12 @@ public class DesignQueryServiceImpl implements DesignQueryService {
   }
 
   @Override
+  @Transactional
   public DesignResDTO.DesignListDTO findShopDesignNameList(Long shopId) {
     if (!shopRepository.existsById(shopId)) {
       throw new ShopException(ShopErrorCode.SHOP_NOT_FOUND);
     }
-    List<DesignResDTO.DesignNameDTO> items =
-        designRepository.findByShopId(shopId).stream()
-            .map(
-                d ->
-                    DesignResDTO.DesignNameDTO.builder()
-                        .designId(d.getId())
-                        .designName(d.getDesignName()) // 필드명: designName
-                        .build())
-            .toList();
+    List<DesignResDTO.DesignNameDTO> items = designRepository.fetchDesignNamesByShopId(shopId);
     return DesignConverter.toShopDesignNameListDTO(items);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.picknwhip_be.domain.design.service;
+package com.example.picknwhip_be.domain.design.service.query;
 
 import com.example.picknwhip_be.domain.design.converter.DesignConverter;
 import com.example.picknwhip_be.domain.design.dto.res.DesignResDTO;
@@ -6,7 +6,6 @@ import com.example.picknwhip_be.domain.design.entity.DesignGallery;
 import com.example.picknwhip_be.domain.design.exception.DesignException;
 import com.example.picknwhip_be.domain.design.exception.code.DesignErrorCode;
 import com.example.picknwhip_be.domain.design.repository.DesignGalleryRepository;
-import com.example.picknwhip_be.domain.design.service.query.DesignQueryService;
 import com.example.picknwhip_be.domain.favorite.entity.FavoriteDesign;
 import com.example.picknwhip_be.domain.favorite.repository.FavoriteDesignRepository;
 import com.example.picknwhip_be.domain.shop.exception.ShopException;
@@ -65,5 +64,22 @@ public class DesignQueryServiceImpl implements DesignQueryService {
             .orElseThrow(() -> new DesignException(DesignErrorCode.DESIGN_NOT_FOUND));
 
     return DesignConverter.toDesignDetailDTO(design);
+  }
+
+  @Override
+  public DesignResDTO.DesignListDTO findShopDesignNameList(Long shopId) {
+    if (!shopRepository.existsById(shopId)) {
+      throw new ShopException(ShopErrorCode.SHOP_NOT_FOUND);
+    }
+    List<DesignResDTO.DesignNameDTO> items =
+        designRepository.findByShopId(shopId).stream()
+            .map(
+                d ->
+                    DesignResDTO.DesignNameDTO.builder()
+                        .designId(d.getId())
+                        .designName(d.getDesignName()) // 필드명: designName
+                        .build())
+            .toList();
+    return DesignConverter.toShopDesignNameListDTO(items);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -1,5 +1,7 @@
 package com.example.picknwhip_be.domain.shop.controller;
 
+import com.example.picknwhip_be.domain.design.dto.res.DesignResDTO;
+import com.example.picknwhip_be.domain.design.service.query.DesignQueryService;
 import com.example.picknwhip_be.domain.review.dto.req.ReviewReqDTO;
 import com.example.picknwhip_be.domain.review.dto.res.ReviewResDTO;
 import com.example.picknwhip_be.domain.review.service.query.ReviewQueryService;
@@ -32,6 +34,7 @@ public class ShopController {
   private final ShopService shopService;
   private final ShopQueryService shopQueryService;
   private final ReviewQueryService reviewQueryService;
+  private final DesignQueryService designQueryService;
 
   @Operation(
       summary = "내 주변 가게 조회",
@@ -85,11 +88,19 @@ public class ShopController {
 
   @Operation(
       summary = "가게 리뷰 통계 조회 by 슝/하승연",
-      description = "가게 리뷰 상단에서 평균 별점과 리뷰 개수, 키워드별 순위를 조회하는 기능입니다. ")
+      description = "가게 리뷰 상단에서 평균 별점과 리뷰 개수, 키워드별 순위를 조회하는 기능입니다.")
   @GetMapping("/{shopId}/reviews/summary")
   public ApiResponse<ReviewResDTO.ShopReviewSummaryDTO> getShopReviewSummary(
       @PathVariable Long shopId) {
     return ApiResponse.of(
         GeneralSuccessCode.OK, reviewQueryService.searchShopReviewSummary(shopId));
+  }
+
+  @Operation(
+      summary = "가게 리뷰 필터 디자인 목록 조회 by 슝/하승연",
+      description = "가게 리뷰 필터에서 디자인 갤러리의 디자인 명단을 조회하는 기능입니다.")
+  @GetMapping("/{shopId}/designs")
+  public ApiResponse<DesignResDTO.DesignListDTO> getShopDesignNameList(@PathVariable Long shopId) {
+    return ApiResponse.of(GeneralSuccessCode.OK, designQueryService.findShopDesignNameList(shopId));
   }
 }


### PR DESCRIPTION
## 💡 Issue
- Close #146 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 가게 리뷰 필터링할 때 디자인 갤러리에 있는 디자인 명단(케이크 이름)을 칩으로 보여주고, 조회 시 id를 보내주어야 하는데 이 API가 없어 구현하였습니다.

## 🛠️ Changes
- ShopController에 API 정의
- design 도메인에서 id, name만 뽑아내도록 구현

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?