### PR TITLE
[FIX/#192] 내 위치 기준으로 주변 가게 조회 API 수정

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -50,7 +50,7 @@ public class ShopController {
       @RequestParam double lat,
       @RequestParam double lon,
       @RequestParam(defaultValue = "1000") double radius) {
-    return ApiResponse.of(GeneralSuccessCode.OK, shopService.getNearbyShops(lat, lon, radius));
+      return ApiResponse.of(GeneralSuccessCode.OK, shopService.getNearbyShops(lat, lon, radius));
   }
 
   @Operation(

--- a/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/controller/ShopController.java
@@ -50,7 +50,7 @@ public class ShopController {
       @RequestParam double lat,
       @RequestParam double lon,
       @RequestParam(defaultValue = "1000") double radius) {
-      return ApiResponse.of(GeneralSuccessCode.OK, shopService.getNearbyShops(lat, lon, radius));
+    return ApiResponse.of(GeneralSuccessCode.OK, shopService.getNearbyShops(lat, lon, radius));
   }
 
   @Operation(

--- a/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
@@ -53,23 +53,26 @@ public class ShopConverter {
         .build();
   }
 
-  public ShopDetailResDTO toDetailDto(ShopRepository.ShopDetailInfo info) {
-    Double distanceInKm = (info.getDistance() != null) ? info.getDistance() / 1000.0 : 0.0;
+    public ShopDetailResDTO toDetailDto(ShopRepository.ShopDetailInfo info) {
 
-    return ShopDetailResDTO.builder()
-        .shopId(info.getShopId())
-        .shopName(info.getShopName())
-        .shopImageUrl(info.getShopImageUrl())
-        .averageRating(info.getAverageRating())
-        .reviewCount(info.getReviewCount())
-        .distance(distanceInKm)
-        .address(info.getAddress())
-        .lat(info.getLat())
-        .lon(info.getLon())
-        .phone(info.getPhone())
-        .keywords(parseTags(info.getKeywords()))
-        .build();
-  }
+        Double distanceKm =
+                (info.getDistanceKm() != null) ? info.getDistanceKm() : 0.0;
+
+        return ShopDetailResDTO.builder()
+                .shopId(info.getShopId())
+                .shopName(info.getShopName())
+                .shopImageUrl(info.getShopImageUrl())
+                .averageRating(info.getAverageRating())
+                .reviewCount(info.getReviewCount())
+                .distanceKm(distanceKm)
+                .address(info.getAddress())
+                .lat(info.getLat())
+                .lon(info.getLon())
+                .phone(info.getPhone())
+                .keywords(parseTags(info.getKeywords()))
+                .build();
+    }
+
 
   public ShopResDTO.ShopInMapListDTO toShopInMapListDTO(List<Shop> shop, Set<Long> pickedShopIds) {
     return ShopResDTO.ShopInMapListDTO.builder()

--- a/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/converter/ShopConverter.java
@@ -53,26 +53,24 @@ public class ShopConverter {
         .build();
   }
 
-    public ShopDetailResDTO toDetailDto(ShopRepository.ShopDetailInfo info) {
+  public ShopDetailResDTO toDetailDto(ShopRepository.ShopDetailInfo info) {
 
-        Double distanceKm =
-                (info.getDistanceKm() != null) ? info.getDistanceKm() : 0.0;
+    Double distanceKm = (info.getDistanceKm() != null) ? info.getDistanceKm() : 0.0;
 
-        return ShopDetailResDTO.builder()
-                .shopId(info.getShopId())
-                .shopName(info.getShopName())
-                .shopImageUrl(info.getShopImageUrl())
-                .averageRating(info.getAverageRating())
-                .reviewCount(info.getReviewCount())
-                .distanceKm(distanceKm)
-                .address(info.getAddress())
-                .lat(info.getLat())
-                .lon(info.getLon())
-                .phone(info.getPhone())
-                .keywords(parseTags(info.getKeywords()))
-                .build();
-    }
-
+    return ShopDetailResDTO.builder()
+        .shopId(info.getShopId())
+        .shopName(info.getShopName())
+        .shopImageUrl(info.getShopImageUrl())
+        .averageRating(info.getAverageRating())
+        .reviewCount(info.getReviewCount())
+        .distanceKm(distanceKm)
+        .address(info.getAddress())
+        .lat(info.getLat())
+        .lon(info.getLon())
+        .phone(info.getPhone())
+        .keywords(parseTags(info.getKeywords()))
+        .build();
+  }
 
   public ShopResDTO.ShopInMapListDTO toShopInMapListDTO(List<Shop> shop, Set<Long> pickedShopIds) {
     return ShopResDTO.ShopInMapListDTO.builder()

--- a/src/main/java/com/example/picknwhip_be/domain/shop/dto/res/ShopDetailResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/dto/res/ShopDetailResDTO.java
@@ -12,7 +12,7 @@ public class ShopDetailResDTO {
   private String shopImageUrl;
   private Double averageRating;
   private Integer reviewCount;
-  private Double distance;
+  private Double distanceKm;
   private String address;
   private String phone;
   private List<String> keywords;

--- a/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
@@ -9,55 +9,56 @@ import org.springframework.data.repository.query.Param;
 
 public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositoryCustom {
 
-    interface ShopPreviewInfo {
-        Long getShopId();
+  interface ShopPreviewInfo {
+    Long getShopId();
 
-        String getShopName();
+    String getShopName();
 
-        String getShopImageUrl();
+    String getShopImageUrl();
 
-        Double getAverageRating();
+    Double getAverageRating();
 
-        Integer getMaxPrice();
+    Integer getMaxPrice();
 
-        Integer getMinPrice();
+    Integer getMinPrice();
 
-        Double getDistance();
+    Double getDistance();
 
-        String getTags();
+    String getTags();
 
-        Double getLat();
+    Double getLat();
 
-        Double getLon();
-    }
+    Double getLon();
+  }
 
-    // 상세 조회용
-    interface ShopDetailInfo {
-        Long getShopId();
+  // 상세 조회용
+  interface ShopDetailInfo {
+    Long getShopId();
 
-        String getShopName();
+    String getShopName();
 
-        String getShopImageUrl();
+    String getShopImageUrl();
 
-        Double getAverageRating();
+    Double getAverageRating();
 
-        Integer getReviewCount();
+    Integer getReviewCount();
 
-        Double getDistanceKm();
+    Double getDistanceKm();
 
-        String getAddress();
+    String getAddress();
 
-        String getPhone();
+    String getPhone();
 
-        String getKeywords();
+    String getKeywords();
 
-        Double getLat();
+    Double getLat();
 
-        Double getLon();
-    }
+    Double getLon();
+  }
 
-    @Query(
-            value = """
+  @Query(
+      value =
+          """
 
                     SELECT s.shop_id as shopId,
              s.shop_name as shopName,
@@ -98,21 +99,18 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositor
       ORDER BY distance ASC
       LIMIT ?8
       """,
-            nativeQuery = true
-    )
-    List<ShopPreviewInfo> findNearbyShops(
-            double lon,
-            double lat,
-            double minLon,
-            double minLat,
-            double maxLat,
-            double maxLon,
-            double radius,
-            int limit
-    );
+      nativeQuery = true)
+  List<ShopPreviewInfo> findNearbyShops(
+      double lon,
+      double lat,
+      double minLon,
+      double minLat,
+      double maxLat,
+      double maxLon,
+      double radius,
+      int limit);
 
-
-    @Query(
+  @Query(
       value =
           "SELECT * FROM shops s "
               + "WHERE s.status = 'ACTIVE' "
@@ -127,20 +125,21 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositor
 
   // 가게 상세 조회
   @Query(
-          value = """
+      value =
+          """
         SELECT s.shop_id as shopId,
                s.shop_name as shopName,
                s.shop_image_url as shopImageUrl,
                IFNULL(s.average_rating, 0.0) as averageRating,
-               (SELECT COUNT(*) 
-                  FROM review r 
-                 WHERE r.shop_id = s.shop_id 
+               (SELECT COUNT(*)
+                  FROM review r
+                 WHERE r.shop_id = s.shop_id
                    AND r.deleted_at IS NULL) as reviewCount,
 
                (ST_Distance_Sphere(
                    s.location,
                    ST_SRID(POINT(:lon, :lat), 4326)
-                ) / 1000.0) as distanceKm, 
+                ) / 1000.0) as distanceKm,
 
                s.address as address,
                s.phone as phone,
@@ -158,11 +157,7 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositor
           AND ST_SRID(s.location) = 4326
         GROUP BY s.shop_id
         """,
-          nativeQuery = true
-  )
+      nativeQuery = true)
   Optional<ShopDetailInfo> findShopDetailById(
-          @Param("shopId") Long shopId,
-          @Param("lat") double lat,
-          @Param("lon") double lon
-  );
-  }
+      @Param("shopId") Long shopId, @Param("lat") double lat, @Param("lon") double lon);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
@@ -56,63 +56,62 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositor
     Double getLon();
   }
 
-  @Query(
-      value =
-          """
-                    SELECT s.shop_id as shopId,
-                           s.shop_name as shopName,
-                           s.shop_image_url as shopImageUrl,
-                           IFNULL(s.average_rating, 0.0) as averageRating,
-                           IFNULL(s.min_price, 0) as minPrice,
-                           IFNULL(s.max_price, 0) as maxPrice,
-                           ST_Distance_Sphere(
-                               s.location,
-                               ST_GeomFromText(CONCAT('POINT(', :lon, ' ', :lat, ')'), 4326)
-                             ) as distance,
-                           COALESCE(JSON_ARRAYAGG(kt.keyword_text), JSON_ARRAY()) as tags,
-                           ST_Longitude(s.location) as lon,
-                           ST_Latitude(s.location) as lat
-                    FROM shops s
-                    LEFT JOIN (
-                        SELECT DISTINCT m.shop_id, k.keyword_text
-                        FROM shop_keyword_mapping m
-                        JOIN shop_appeal_keywords k ON m.keyword_id = k.keyword_id
-                    ) kt ON s.shop_id = kt.shop_id
-                    WHERE s.status = 'ACTIVE'
-                      AND ST_SRID(s.location) = 4326
-                      AND MBRWithin(
-                        s.location,
-                        ST_GeomFromText(
-                          CONCAT('POLYGON((',
-                            :minLat, ' ', :minLon, ',',
-                            :maxLat, ' ', :minLon, ',',
-                            :maxLat, ' ', :maxLon, ',',
-                            :minLat, ' ', :maxLon, ',',
-                            :minLat, ' ', :minLon,
-                          '))'),
-                          4326
-                        )
-                      )
-                      AND ST_Distance_Sphere(
-                            s.location,
-                            ST_GeomFromText(CONCAT('POINT(', :lat, ' ', :lon, ')'), 4326)
-                          ) <= :radius
-                    GROUP BY s.shop_id
-                    ORDER BY distance ASC
-                    LIMIT :limit
-                    """,
-      nativeQuery = true)
-  List<ShopPreviewInfo> findNearbyShops(
-      @Param("lat") double lat,
-      @Param("lon") double lon,
-      @Param("minLat") double minLat,
-      @Param("maxLat") double maxLat,
-      @Param("minLon") double minLon,
-      @Param("maxLon") double maxLon,
-      @Param("radius") double radius,
-      @Param("limit") int limit);
+    @Query(
+            value = """
+      SELECT s.shop_id as shopId,
+             s.shop_name as shopName,
+             s.shop_image_url as shopImageUrl,
+             IFNULL(s.average_rating, 0.0) as averageRating,
+             IFNULL(s.min_price, 0) as minPrice,
+             IFNULL(s.max_price, 0) as maxPrice,
+             ST_Distance_Sphere(
+                 s.location,
+                 ST_SRID(POINT(?1, ?2), 4326)
+               ) as distance,
+             COALESCE(JSON_ARRAYAGG(kt.keyword_text), JSON_ARRAY()) as tags,
+             ST_Longitude(s.location) as lon,
+             ST_Latitude(s.location) as lat
+      FROM shops s
+      LEFT JOIN (
+          SELECT DISTINCT m.shop_id, k.keyword_text
+          FROM shop_keyword_mapping m
+          JOIN shop_appeal_keywords k ON m.keyword_id = k.keyword_id
+      ) kt ON s.shop_id = kt.shop_id
+      WHERE s.status = 'ACTIVE'
+        AND ST_SRID(s.location) = 4326
+        AND MBRContains(
+          ST_SRID(
+            ST_MakeEnvelope(
+              POINT(?3, ?4),
+              POINT(?6, ?5)
+            ),
+            4326
+          ),
+          s.location
+        )
+        AND ST_Distance_Sphere(
+              s.location,
+              ST_SRID(POINT(?1, ?2), 4326)
+            ) <= ?7
+      GROUP BY s.shop_id
+      ORDER BY distance ASC
+      LIMIT ?8
+      """,
+            nativeQuery = true
+    )
+    List<ShopPreviewInfo> findNearbyShops(
+            double lon,
+            double lat,
+            double minLon,
+            double minLat,
+            double maxLat,
+            double maxLon,
+            double radius,
+            int limit
+    );
 
-  @Query(
+
+    @Query(
       value =
           "SELECT * FROM shops s "
               + "WHERE s.status = 'ACTIVE' "
@@ -136,7 +135,7 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositor
                          (SELECT COUNT(*) FROM review r WHERE r.shop_id = s.shop_id AND r.deleted_at IS NULL) as reviewCount,
                          ST_Distance_Sphere(
                             s.location,
-                            ST_GeomFromText(CONCAT('POINT(', :lat, ' ', :lon, ')'), 4326)
+                            ST_GeomFromText(CONCAT('POINT(', :lon, ' ', :lat, ')'), 4326)
                          ) as distance,
                          s.address as address,
                          s.phone as phone,

--- a/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/repository/ShopRepository.java
@@ -9,56 +9,57 @@ import org.springframework.data.repository.query.Param;
 
 public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositoryCustom {
 
-  interface ShopPreviewInfo {
-    Long getShopId();
+    interface ShopPreviewInfo {
+        Long getShopId();
 
-    String getShopName();
+        String getShopName();
 
-    String getShopImageUrl();
+        String getShopImageUrl();
 
-    Double getAverageRating();
+        Double getAverageRating();
 
-    Integer getMaxPrice();
+        Integer getMaxPrice();
 
-    Integer getMinPrice();
+        Integer getMinPrice();
 
-    Double getDistance();
+        Double getDistance();
 
-    String getTags();
+        String getTags();
 
-    Double getLat();
+        Double getLat();
 
-    Double getLon();
-  }
+        Double getLon();
+    }
 
-  // 상세 조회용
-  interface ShopDetailInfo {
-    Long getShopId();
+    // 상세 조회용
+    interface ShopDetailInfo {
+        Long getShopId();
 
-    String getShopName();
+        String getShopName();
 
-    String getShopImageUrl();
+        String getShopImageUrl();
 
-    Double getAverageRating();
+        Double getAverageRating();
 
-    Integer getReviewCount();
+        Integer getReviewCount();
 
-    Double getDistance();
+        Double getDistanceKm();
 
-    String getAddress();
+        String getAddress();
 
-    String getPhone();
+        String getPhone();
 
-    String getKeywords();
+        String getKeywords();
 
-    Double getLat();
+        Double getLat();
 
-    Double getLon();
-  }
+        Double getLon();
+    }
 
     @Query(
             value = """
-      SELECT s.shop_id as shopId,
+
+                    SELECT s.shop_id as shopId,
              s.shop_name as shopName,
              s.shop_image_url as shopImageUrl,
              IFNULL(s.average_rating, 0.0) as averageRating,
@@ -126,32 +127,42 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositor
 
   // 가게 상세 조회
   @Query(
-      value =
-          """
-                  SELECT s.shop_id as shopId,
-                         s.shop_name as shopName,
-                         s.shop_image_url as shopImageUrl,
-                         IFNULL(s.average_rating, 0.0) as averageRating,
-                         (SELECT COUNT(*) FROM review r WHERE r.shop_id = s.shop_id AND r.deleted_at IS NULL) as reviewCount,
-                         ST_Distance_Sphere(
-                            s.location,
-                            ST_GeomFromText(CONCAT('POINT(', :lon, ' ', :lat, ')'), 4326)
-                         ) as distance,
-                         s.address as address,
-                         s.phone as phone,
-                         COALESCE(JSON_ARRAYAGG(kt.keyword_text), JSON_ARRAY()) as keywords,
-                         ST_Longitude(s.location) as lon,
-                         ST_Latitude(s.location) as lat
-                  FROM shops s
-                  LEFT JOIN (
-                      SELECT DISTINCT m.shop_id, k.keyword_text
-                      FROM shop_keyword_mapping m
-                      JOIN shop_appeal_keywords k ON m.keyword_id = k.keyword_id
-                  ) kt ON s.shop_id = kt.shop_id
-                  WHERE s.shop_id = :shopId AND s.status = 'ACTIVE'
-                  GROUP BY s.shop_id
-                  """,
-      nativeQuery = true)
+          value = """
+        SELECT s.shop_id as shopId,
+               s.shop_name as shopName,
+               s.shop_image_url as shopImageUrl,
+               IFNULL(s.average_rating, 0.0) as averageRating,
+               (SELECT COUNT(*) 
+                  FROM review r 
+                 WHERE r.shop_id = s.shop_id 
+                   AND r.deleted_at IS NULL) as reviewCount,
+
+               (ST_Distance_Sphere(
+                   s.location,
+                   ST_SRID(POINT(:lon, :lat), 4326)
+                ) / 1000.0) as distanceKm, 
+
+               s.address as address,
+               s.phone as phone,
+               COALESCE(JSON_ARRAYAGG(kt.keyword_text), JSON_ARRAY()) as keywords,
+               ST_Longitude(s.location) as lon,
+               ST_Latitude(s.location) as lat
+        FROM shops s
+        LEFT JOIN (
+            SELECT DISTINCT m.shop_id, k.keyword_text
+            FROM shop_keyword_mapping m
+            JOIN shop_appeal_keywords k ON m.keyword_id = k.keyword_id
+        ) kt ON s.shop_id = kt.shop_id
+        WHERE s.shop_id = :shopId
+          AND s.status = 'ACTIVE'
+          AND ST_SRID(s.location) = 4326
+        GROUP BY s.shop_id
+        """,
+          nativeQuery = true
+  )
   Optional<ShopDetailInfo> findShopDetailById(
-      @Param("shopId") Long shopId, @Param("lat") double lat, @Param("lon") double lon);
-}
+          @Param("shopId") Long shopId,
+          @Param("lat") double lat,
+          @Param("lon") double lon
+  );
+  }

--- a/src/main/java/com/example/picknwhip_be/domain/shop/service/command/ShopServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/service/command/ShopServiceImpl.java
@@ -44,31 +44,33 @@ public class ShopServiceImpl implements ShopService {
     }
 
     GeoUtils.BoundingBox box = GeoUtils.normalize(GeoUtils.boundingBox(lat, lon, radius));
-      System.out.println(
-              "BOX minLat=" + box.minLat()
-                      + ", maxLat=" + box.maxLat()
-                      + ", minLon=" + box.minLon()
-                      + ", maxLon=" + box.maxLon()
-      );
-      try {
-          return shopRepository
-                  .findNearbyShops(
-                          lon,
-                          lat,
-                          box.minLon(),
-                          box.minLat(),
-                          box.maxLat(),
-                          box.maxLon(),
-                          radius,
-                          DEFAULT_LIMIT
-                  )
-                  .stream()
-                  .map(shopConverter::toPreviewDto)
-                  .toList();
+    System.out.println(
+        "BOX minLat="
+            + box.minLat()
+            + ", maxLat="
+            + box.maxLat()
+            + ", minLon="
+            + box.minLon()
+            + ", maxLon="
+            + box.maxLon());
+    try {
+      return shopRepository
+          .findNearbyShops(
+              lon,
+              lat,
+              box.minLon(),
+              box.minLat(),
+              box.maxLat(),
+              box.maxLon(),
+              radius,
+              DEFAULT_LIMIT)
+          .stream()
+          .map(shopConverter::toPreviewDto)
+          .toList();
 
-      } catch (Exception e) {
-          throw new ShopException(ShopErrorCode.SHOP_NEARBY_QUERY_FAILED);
-      }
+    } catch (Exception e) {
+      throw new ShopException(ShopErrorCode.SHOP_NEARBY_QUERY_FAILED);
+    }
   }
 
   @Override

--- a/src/main/java/com/example/picknwhip_be/domain/shop/service/command/ShopServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/service/command/ShopServiceImpl.java
@@ -16,9 +16,11 @@ import com.example.picknwhip_be.global.apiPayload.util.GeoUtils;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -44,15 +46,12 @@ public class ShopServiceImpl implements ShopService {
     }
 
     GeoUtils.BoundingBox box = GeoUtils.normalize(GeoUtils.boundingBox(lat, lon, radius));
-    System.out.println(
-        "BOX minLat="
-            + box.minLat()
-            + ", maxLat="
-            + box.maxLat()
-            + ", minLon="
-            + box.minLon()
-            + ", maxLon="
-            + box.maxLon());
+    log.debug(
+        "BOX minLat={}, maxLat={}, minLon={}, maxLon={}",
+        box.minLat(),
+        box.maxLat(),
+        box.minLon(),
+        box.maxLon());
     try {
       return shopRepository
           .findNearbyShops(

--- a/src/main/java/com/example/picknwhip_be/domain/shop/service/command/ShopServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/shop/service/command/ShopServiceImpl.java
@@ -44,24 +44,31 @@ public class ShopServiceImpl implements ShopService {
     }
 
     GeoUtils.BoundingBox box = GeoUtils.normalize(GeoUtils.boundingBox(lat, lon, radius));
+      System.out.println(
+              "BOX minLat=" + box.minLat()
+                      + ", maxLat=" + box.maxLat()
+                      + ", minLon=" + box.minLon()
+                      + ", maxLon=" + box.maxLon()
+      );
+      try {
+          return shopRepository
+                  .findNearbyShops(
+                          lon,
+                          lat,
+                          box.minLon(),
+                          box.minLat(),
+                          box.maxLat(),
+                          box.maxLon(),
+                          radius,
+                          DEFAULT_LIMIT
+                  )
+                  .stream()
+                  .map(shopConverter::toPreviewDto)
+                  .toList();
 
-    try {
-      return shopRepository
-          .findNearbyShops(
-              lat,
-              lon,
-              box.minLat(),
-              box.maxLat(),
-              box.minLon(),
-              box.maxLon(),
-              radius,
-              DEFAULT_LIMIT)
-          .stream()
-          .map(shopConverter::toPreviewDto)
-          .toList();
-    } catch (Exception e) {
-      throw new ShopException(ShopErrorCode.SHOP_NEARBY_QUERY_FAILED);
-    }
+      } catch (Exception e) {
+          throw new ShopException(ShopErrorCode.SHOP_NEARBY_QUERY_FAILED);
+      }
   }
 
   @Override


### PR DESCRIPTION
## 💡 Issue
- Close #192 
  (이슈 번호를 입력하면 PR이 머지될 때 이슈가 자동으로 닫힙니다)

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [x] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 내 좌표, box, db에 저장된 location이 정상임에도 Latitude 126.xxx 같은 에러가 거듭 발생합니다.
=> WKT 문자열 파싱 구간에서 꼬임이 핵심 원인입니다.
 Hibernate 네이티브 쿼리에서 파라미터가 여러 번 반복되거나 문자열로 엮이면 바인딩/파싱이 꼬여서 제대로 된 로직임에도 같은 오류가 반복해서 발생합니다.
- 기존에 사용하던 문자열 파싱을 없애고 MySQL이 직접 geometry를 생성하도록 합니다. 
- Bounding Box 처리 방식을 변경합니다: 기존에는 풀리곤을 문자열로 직접 생성했지만 이 경우 좌표쌍이 여러개라서 바인딩 이슈가 발생하여 사각형을 함수로 생성하여 MBRContains로 포함 여부를 체크하는 방식으로 변경합니다. 

## 🛠️ Changes
- [x] repository 파라미터 전달 방식 변경
- [x] 가게 상세조회 API 최적화: converter에서 처리하던것을 변경하여 응답에서 바로 distanceKm로 변경합니

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)
<img width="936" height="734" alt="스크린샷 2026-02-15 033731" src="https://github.com/user-attachments/assets/c9a1e291-af60-48e6-b9d2-32247af4fca5" />
<img width="1048" height="552" alt="스크린샷 2026-02-15 034031" src="https://github.com/user-attachments/assets/59d5e329-d688-406a-9ec7-48637d26af4c" />

## ✅ Checklist
- [ ] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] develop 브랜치의 최신 사항을 pull 받았나요?
- [ ] 테스트(빌드)가 성공적으로 통과했나요?