### PR TITLE
[FEAT] refreshtoken 발급

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -16,9 +16,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "사용자 관련 API")
@@ -30,13 +32,17 @@ public class UserRestController {
   private final UserQueryService userQueryService;
   private final UserCommandService userCommandService;
 
+  @Value("${jwt.refresh-token-validity:1209600000}")
+  private long refreshTokenValidityInMilliseconds; // 14일 기본값 (ms)
+
   @Operation(
       summary = "리프레시토큰 발급 API",
       description = "액세스 토큰 만료 시 호출합니다. 쿠키 또는 body의 refreshToken을 사용합니다.")
   @PostMapping("/refresh")
   public ApiResponse<UserResDTO.TokenResponseDTO> refresh(
       @RequestBody(required = false) UserReqDTO.RefreshTokenReqDTO dto,
-      HttpServletRequest request) {
+      HttpServletRequest request,
+      HttpServletResponse response) {
     String token =
         CookieUtils.getCookie(request, "refreshToken")
             .map(Cookie::getValue)
@@ -46,7 +52,13 @@ public class UserRestController {
     if (token == null || token.isBlank()) {
       throw new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN);
     }
-    return ApiResponse.of(GeneralSuccessCode.OK, userCommandService.refreshAccessToken(token));
+    UserResDTO.TokenResponseDTO result = userCommandService.refreshAccessToken(token);
+    int cookieMaxAge = (int) (refreshTokenValidityInMilliseconds / 1000);
+
+    CookieUtils.addRefreshTokenCookie(
+        response, "refreshToken", result.getRefreshToken(), cookieMaxAge);
+
+    return ApiResponse.of(GeneralSuccessCode.OK, result);
   }
 
   @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호, 생일을 입력받아 업데이트합니다.")
@@ -82,11 +94,14 @@ public class UserRestController {
 
   @Operation(summary = "로그아웃 API", description = "서버 세션을 만료시키고 카카오 로그아웃을 수행합니다.")
   @PostMapping("/logout")
-  public ApiResponse<String> createLogout(@ExtractPayload Long userId, HttpServletRequest request) {
+  public ApiResponse<String> createLogout(
+      @ExtractPayload Long userId, HttpServletRequest request, HttpServletResponse response) {
     try {
-      // 카카오 서버 로그아웃
+      // 카카오 서버 로그아웃 + DB 리프레시 토큰 삭제
       userCommandService.logout(userId);
     } finally {
+      // 리프레시 토큰 쿠키 삭제
+      CookieUtils.deleteCookie(request, response, "refreshToken");
       // 서버 세션 무효화
       HttpSession session = request.getSession(false);
       if (session != null) {

--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -8,9 +8,13 @@ import com.example.picknwhip_be.domain.user.service.command.UserCommandService;
 import com.example.picknwhip_be.domain.user.service.query.UserQueryService;
 import com.example.picknwhip_be.global.apiPayload.ApiResponse;
 import com.example.picknwhip_be.global.apiPayload.annotation.ExtractPayload;
+import com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode;
 import com.example.picknwhip_be.global.apiPayload.code.GeneralSuccessCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import com.example.picknwhip_be.global.apiPayload.util.CookieUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -25,6 +29,25 @@ public class UserRestController {
 
   private final UserQueryService userQueryService;
   private final UserCommandService userCommandService;
+
+  @Operation(
+      summary = "리프레시토큰 발급 API",
+      description = "액세스 토큰 만료 시 호출합니다. 쿠키 또는 body의 refreshToken을 사용합니다.")
+  @PostMapping("/refresh")
+  public ApiResponse<UserResDTO.TokenResponseDTO> refresh(
+      @RequestBody(required = false) UserReqDTO.RefreshTokenReqDTO dto,
+      HttpServletRequest request) {
+    String token =
+        CookieUtils.getCookie(request, "refreshToken")
+            .map(Cookie::getValue)
+            .orElseGet(
+                () ->
+                    (dto != null && dto.getRefreshToken() != null) ? dto.getRefreshToken() : null);
+    if (token == null || token.isBlank()) {
+      throw new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+    return ApiResponse.of(GeneralSuccessCode.OK, userCommandService.refreshAccessToken(token));
+  }
 
   @Operation(summary = "신규 가입 유저 추가 정보 저장 API", description = "이름과 휴대폰 번호, 생일을 입력받아 업데이트합니다.")
   @PostMapping("/extra/info")

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/req/UserReqDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/req/UserReqDTO.java
@@ -31,6 +31,13 @@ public class UserReqDTO {
   @Getter
   @NoArgsConstructor
   @AllArgsConstructor
+  public static class RefreshTokenReqDTO {
+    private String refreshToken;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class WithdrawalDTO {
     private List<WithdrawalReason> reasons;
     private String feedback;

--- a/src/main/java/com/example/picknwhip_be/domain/user/dto/res/UserResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/dto/res/UserResDTO.java
@@ -28,4 +28,11 @@ public class UserResDTO {
     private Long userId;
     private LocalDateTime updatedAt;
   }
+
+  @Builder
+  @Getter
+  public static class TokenResponseDTO {
+    private String accessToken;
+    private String refreshToken;
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/RefreshToken.java
@@ -1,0 +1,40 @@
+package com.example.picknwhip_be.domain.user.entity;
+
+import com.example.picknwhip_be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String token;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false)
+  private LocalDateTime expiryDate;
+
+  @Builder
+  public RefreshToken(String token, Long userId, LocalDateTime expiryDate) {
+    this.token = token;
+    this.userId = userId;
+    this.expiryDate = expiryDate;
+  }
+
+  public void updateToken(String newToken, LocalDateTime newExpiryDate) {
+    this.token = newToken;
+    this.expiryDate = newExpiryDate;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/RefreshToken.java
@@ -17,10 +17,10 @@ public class RefreshToken extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false, unique = true, length = 512)
   private String token;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private Long userId;
 
   @Column(nullable = false)

--- a/src/main/java/com/example/picknwhip_be/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.example.picknwhip_be.domain.user.repository;
+
+import com.example.picknwhip_be.domain.user.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+  Optional<RefreshToken> findByToken(String token);
+
+  Optional<RefreshToken> findByUserId(Long userId);
+
+  void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandService.java
@@ -21,5 +21,7 @@ public interface UserCommandService {
 
   void logout(Long userId);
 
+  void saveOrUpdateRefreshToken(Long userId, String tokenValue);
+
   UserResDTO.TokenResponseDTO refreshAccessToken(String refreshTokenRequest);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandService.java
@@ -1,6 +1,7 @@
 package com.example.picknwhip_be.domain.user.service.command;
 
 import com.example.picknwhip_be.domain.user.dto.req.UserReqDTO;
+import com.example.picknwhip_be.domain.user.dto.res.UserResDTO;
 import com.example.picknwhip_be.domain.user.entity.User;
 
 public interface UserCommandService {
@@ -19,4 +20,6 @@ public interface UserCommandService {
   void withdrawMember(Long userId, UserReqDTO.WithdrawalDTO request);
 
   void logout(Long userId);
+
+  UserResDTO.TokenResponseDTO refreshAccessToken(String refreshTokenRequest);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
@@ -1,14 +1,21 @@
 package com.example.picknwhip_be.domain.user.service.command;
 
 import com.example.picknwhip_be.domain.user.dto.req.UserReqDTO;
+import com.example.picknwhip_be.domain.user.dto.res.UserResDTO;
+import com.example.picknwhip_be.domain.user.entity.RefreshToken;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.entity.UserWithdrawal;
 import com.example.picknwhip_be.domain.user.entity.WithdrawalReasonItem;
 import com.example.picknwhip_be.domain.user.exception.UserException;
 import com.example.picknwhip_be.domain.user.exception.code.UserErrorCode;
+import com.example.picknwhip_be.domain.user.repository.RefreshTokenRepository;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import com.example.picknwhip_be.domain.user.repository.UserWithdrawalRepository;
 import com.example.picknwhip_be.domain.user.repository.WithdrawalReasonItemRepository;
+import com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode;
+import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
+import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +39,8 @@ public class UserCommandServiceImpl implements UserCommandService {
   private final UserRepository userRepository;
   private final UserWithdrawalRepository userWithdrawalRepository;
   private final WithdrawalReasonItemRepository reasonItemRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtTokenProvider jwtTokenProvider;
   private final OAuth2AuthorizedClientService authorizedClientService;
   private final RestTemplate restTemplate = new RestTemplate();
   private static final int MAX_NICKNAME_GENERATION_ATTEMPTS = 20;
@@ -201,5 +210,33 @@ public class UserCommandServiceImpl implements UserCommandService {
     } catch (RestClientException e) {
       log.error("카카오 로그아웃 API 실패: {}", e.getMessage());
     }
+
+    // DB 리프레시 토큰 삭제 (로그아웃 시 재사용 방지)
+    refreshTokenRepository.deleteByUserId(userId);
+  }
+
+  @Override
+  @Transactional
+  public UserResDTO.TokenResponseDTO refreshAccessToken(String refreshTokenRequest) {
+    RefreshToken refreshToken =
+        refreshTokenRepository
+            .findByToken(refreshTokenRequest)
+            .orElseThrow(() -> new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+    if (refreshToken.getExpiryDate().isBefore(LocalDateTime.now())) {
+      refreshTokenRepository.delete(refreshToken);
+      throw new GeneralException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+    }
+
+    // 새 액세스 토큰 생성
+    String newAccessToken = jwtTokenProvider.createToken(refreshToken.getUserId());
+
+    String newRefreshTokenValue = jwtTokenProvider.createRefreshToken(refreshToken.getUserId());
+    refreshToken.updateToken(newRefreshTokenValue, LocalDateTime.now().plusDays(14));
+
+    return UserResDTO.TokenResponseDTO.builder()
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshTokenValue)
+        .build();
   }
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
@@ -15,6 +15,7 @@ import com.example.picknwhip_be.domain.user.repository.WithdrawalReasonItemRepos
 import com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,9 @@ public class UserCommandServiceImpl implements UserCommandService {
 
   @Value("${cloud.aws.region:ap-northeast-2}")
   private String region;
+
+  @Value("${jwt.refresh-token-validity:1209600000}")
+  private long refreshTokenValidityInMilliseconds; // 14일 기본값
 
   @Override
   public User joinOrCreateUser(
@@ -216,6 +220,28 @@ public class UserCommandServiceImpl implements UserCommandService {
   }
 
   @Override
+  public void saveOrUpdateRefreshToken(Long userId, String tokenValue) {
+    LocalDateTime expiryDate =
+        LocalDateTime.now().plus(Duration.ofMillis(refreshTokenValidityInMilliseconds));
+    RefreshToken refreshToken =
+        refreshTokenRepository
+            .findByUserId(userId)
+            .map(
+                entity -> {
+                  entity.updateToken(tokenValue, expiryDate);
+                  return entity;
+                })
+            .orElseGet(
+                () ->
+                    RefreshToken.builder()
+                        .token(tokenValue)
+                        .userId(userId)
+                        .expiryDate(expiryDate)
+                        .build());
+    refreshTokenRepository.save(refreshToken);
+  }
+
+  @Override
   @Transactional
   public UserResDTO.TokenResponseDTO refreshAccessToken(String refreshTokenRequest) {
     RefreshToken refreshToken =
@@ -232,7 +258,9 @@ public class UserCommandServiceImpl implements UserCommandService {
     String newAccessToken = jwtTokenProvider.createToken(refreshToken.getUserId());
 
     String newRefreshTokenValue = jwtTokenProvider.createRefreshToken(refreshToken.getUserId());
-    refreshToken.updateToken(newRefreshTokenValue, LocalDateTime.now().plusDays(14));
+    LocalDateTime newExpiryDate =
+        LocalDateTime.now().plus(Duration.ofMillis(refreshTokenValidityInMilliseconds));
+    refreshToken.updateToken(newRefreshTokenValue, newExpiryDate);
 
     return UserResDTO.TokenResponseDTO.builder()
         .accessToken(newAccessToken)

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/code/AuthErrorCode.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/code/AuthErrorCode.java
@@ -11,7 +11,9 @@ public enum AuthErrorCode implements BaseErrorCode {
   TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰이 만료되었습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "유효하지 않은 토큰입니다."),
   TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_4", "인증 헤더에 토큰이 없습니다."),
-  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "해당 리소스에 대한 접근 권한이 없습니다.");
+  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "해당 리소스에 대한 접근 권한이 없습니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_5", "리프레시 토큰이 유효하지 않습니다."),
+  REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "리프레시 토큰이 만료되었습니다. 다시 로그인해주세요."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
@@ -58,8 +58,9 @@ public class SecurityConfig {
                     .requestMatchers("/api/users/extra/info")
                     .authenticated()
                     .requestMatchers("/api/test/**")
-                    .permitAll() // 테스트 API 허용 추가
-
+                    .permitAll()
+                    .requestMatchers("/api/users/refresh")
+                    .permitAll()
                     // 그 외 모든 API는 인증 필요
                     .anyRequest()
                     .authenticated())

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,12 +1,16 @@
 package com.example.picknwhip_be.global.apiPayload.handler;
 
 import com.example.picknwhip_be.domain.user.dto.auth.KakaoUserInfo;
+import com.example.picknwhip_be.domain.user.entity.RefreshToken;
 import com.example.picknwhip_be.domain.user.entity.User;
+import com.example.picknwhip_be.domain.user.repository.RefreshTokenRepository;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import com.example.picknwhip_be.global.apiPayload.util.CookieUtils;
 import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -20,6 +24,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
   private final UserRepository userRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
   private final JwtTokenProvider jwtTokenProvider;
 
   @Value("${app.frontend-url}")
@@ -39,10 +44,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             .findByKakaoId(kakaoId)
             .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다. kakaoId: " + kakaoId));
 
-    // JWT 토큰 생성
     String accessToken = jwtTokenProvider.createToken(user.getUserId());
 
-    // 리다이렉트 경로 설정 및 토큰 전달
+    String refreshTokenValue = jwtTokenProvider.createRefreshToken(user.getUserId());
+    saveOrUpdateRefreshToken(user, refreshTokenValue);
+
+    int cookieMaxAge = 60 * 60 * 24 * 14;
+    CookieUtils.addCookie(response, "refreshToken", refreshTokenValue, cookieMaxAge);
+
     String targetUrl;
     if (user.getName() == null || user.getPhone() == null || user.getBirthdate() == null) {
       targetUrl =
@@ -51,7 +60,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
               .build()
               .toUriString();
     } else {
-      // 이미 가입된 유저인 경우 홈으로 이동
       targetUrl =
           UriComponentsBuilder.fromUriString(frontendUrl + "/")
               .queryParam("accessToken", accessToken)
@@ -60,5 +68,25 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     }
 
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
+  }
+
+  private void saveOrUpdateRefreshToken(User user, String tokenValue) {
+    RefreshToken refreshToken =
+        refreshTokenRepository
+            .findByUserId(user.getUserId())
+            .map(
+                entity -> {
+                  entity.updateToken(tokenValue, LocalDateTime.now().plusDays(14));
+                  return entity;
+                })
+            .orElseGet(
+                () ->
+                    RefreshToken.builder()
+                        .token(tokenValue)
+                        .userId(user.getUserId())
+                        .expiryDate(LocalDateTime.now().plusDays(14))
+                        .build());
+
+    refreshTokenRepository.save(refreshToken);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -4,7 +4,6 @@ import com.example.picknwhip_be.domain.user.dto.auth.KakaoUserInfo;
 import com.example.picknwhip_be.domain.user.entity.User;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import com.example.picknwhip_be.domain.user.service.command.UserCommandService;
-import com.example.picknwhip_be.global.apiPayload.util.CookieUtils;
 import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -51,7 +50,17 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     userCommandService.saveOrUpdateRefreshToken(user.getUserId(), refreshTokenValue);
 
     int cookieMaxAge = (int) (refreshTokenValidityInMilliseconds / 1000);
-    CookieUtils.addRefreshTokenCookie(response, "refreshToken", refreshTokenValue, cookieMaxAge);
+
+    org.springframework.http.ResponseCookie cookie =
+        org.springframework.http.ResponseCookie.from("refreshToken", refreshTokenValue)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(cookieMaxAge)
+            .sameSite("Lax")
+            .build();
+
+    response.addHeader("Set-Cookie", cookie.toString());
 
     String targetUrl;
     if (user.getName() == null || user.getPhone() == null || user.getBirthdate() == null) {

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,16 +1,14 @@
 package com.example.picknwhip_be.global.apiPayload.handler;
 
 import com.example.picknwhip_be.domain.user.dto.auth.KakaoUserInfo;
-import com.example.picknwhip_be.domain.user.entity.RefreshToken;
 import com.example.picknwhip_be.domain.user.entity.User;
-import com.example.picknwhip_be.domain.user.repository.RefreshTokenRepository;
 import com.example.picknwhip_be.domain.user.repository.UserRepository;
+import com.example.picknwhip_be.domain.user.service.command.UserCommandService;
 import com.example.picknwhip_be.global.apiPayload.util.CookieUtils;
 import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -24,11 +22,14 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
   private final UserRepository userRepository;
-  private final RefreshTokenRepository refreshTokenRepository;
+  private final UserCommandService userCommandService;
   private final JwtTokenProvider jwtTokenProvider;
 
   @Value("${app.frontend-url}")
   private String frontendUrl;
+
+  @Value("${jwt.refresh-token-validity:1209600000}")
+  private long refreshTokenValidityInMilliseconds; // 14일 기본값 (ms)
 
   @Override
   public void onAuthenticationSuccess(
@@ -47,10 +48,10 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     String accessToken = jwtTokenProvider.createToken(user.getUserId());
 
     String refreshTokenValue = jwtTokenProvider.createRefreshToken(user.getUserId());
-    saveOrUpdateRefreshToken(user, refreshTokenValue);
+    userCommandService.saveOrUpdateRefreshToken(user.getUserId(), refreshTokenValue);
 
-    int cookieMaxAge = 60 * 60 * 24 * 14;
-    CookieUtils.addCookie(response, "refreshToken", refreshTokenValue, cookieMaxAge);
+    int cookieMaxAge = (int) (refreshTokenValidityInMilliseconds / 1000);
+    CookieUtils.addRefreshTokenCookie(response, "refreshToken", refreshTokenValue, cookieMaxAge);
 
     String targetUrl;
     if (user.getName() == null || user.getPhone() == null || user.getBirthdate() == null) {
@@ -68,25 +69,5 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     }
 
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
-  }
-
-  private void saveOrUpdateRefreshToken(User user, String tokenValue) {
-    RefreshToken refreshToken =
-        refreshTokenRepository
-            .findByUserId(user.getUserId())
-            .map(
-                entity -> {
-                  entity.updateToken(tokenValue, LocalDateTime.now().plusDays(14));
-                  return entity;
-                })
-            .orElseGet(
-                () ->
-                    RefreshToken.builder()
-                        .token(tokenValue)
-                        .userId(user.getUserId())
-                        .expiryDate(LocalDateTime.now().plusDays(14))
-                        .build());
-
-    refreshTokenRepository.save(refreshToken);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/util/CookieUtils.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/util/CookieUtils.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Optional;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
 import org.springframework.security.oauth2.client.jackson2.OAuth2ClientJackson2Module;
 
@@ -40,6 +42,20 @@ public class CookieUtils {
     cookie.setSecure(true);
     cookie.setMaxAge(maxAge);
     response.addCookie(cookie);
+  }
+
+  /** 리프레시 토큰용 쿠키 추가. SameSite=Lax 설정으로 CSRF 취약점 방지. */
+  public static void addRefreshTokenCookie(
+      HttpServletResponse response, String name, String value, int maxAge) {
+    ResponseCookie cookie =
+        ResponseCookie.from(name, value)
+            .path("/")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Lax")
+            .maxAge(Duration.ofSeconds(maxAge))
+            .build();
+    response.addHeader("Set-Cookie", cookie.toString());
   }
 
   public static void deleteCookie(

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
@@ -34,9 +34,12 @@ public class JwtTokenProvider {
     this.key = Keys.hmacShaKeyFor(secretKeyPlain.getBytes(StandardCharsets.UTF_8));
   }
 
-  // 토큰 생성
+  private static final String TOKEN_TYPE_ACCESS = "access";
+  private static final String TOKEN_TYPE_REFRESH = "refresh";
+
+  // 액세스 토큰 생성
   public String createToken(Long userId) {
-    Claims claims = Jwts.claims().subject(userId.toString()).build();
+    Claims claims = Jwts.claims().subject(userId.toString()).add("type", TOKEN_TYPE_ACCESS).build();
     Date now = new Date();
     Date validity = new Date(now.getTime() + tokenValidityInMilliseconds);
 
@@ -59,7 +62,11 @@ public class JwtTokenProvider {
   // 토큰 유효성 및 만료 기간 검증
   public boolean validateToken(String token) {
     try {
-      Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+      Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+      if (!TOKEN_TYPE_ACCESS.equals(claims.get("type", String.class))) {
+        throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
+            com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
+      }
       return true;
     } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
       throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
@@ -76,8 +83,10 @@ public class JwtTokenProvider {
     }
   }
 
+  // 리프레시 토큰 생성
   public String createRefreshToken(Long userId) {
-    Claims claims = Jwts.claims().subject(String.valueOf(userId)).build();
+    Claims claims =
+        Jwts.claims().subject(String.valueOf(userId)).add("type", TOKEN_TYPE_REFRESH).build();
     Date now = new Date();
     Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
 
@@ -89,6 +98,12 @@ public class JwtTokenProvider {
       return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
     } catch (ExpiredJwtException e) {
       return e.getClaims();
+    } catch (io.jsonwebtoken.security.SecurityException
+        | MalformedJwtException
+        | UnsupportedJwtException
+        | IllegalArgumentException e) {
+      throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
+          com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
     }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
@@ -24,6 +24,9 @@ public class JwtTokenProvider {
   @Value("${jwt.access-token-validity}")
   private long tokenValidityInMilliseconds;
 
+  @Value("${jwt.refresh-token-validity:1209600000}")
+  private long refreshTokenValidityInMilliseconds; // 14일 기본값
+
   private SecretKey key;
 
   @PostConstruct
@@ -70,6 +73,22 @@ public class JwtTokenProvider {
     } catch (IllegalArgumentException e) {
       throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
           com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
+    }
+  }
+
+  public String createRefreshToken(Long userId) {
+    Claims claims = Jwts.claims().subject(String.valueOf(userId)).build();
+    Date now = new Date();
+    Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+
+    return Jwts.builder().claims(claims).issuedAt(now).expiration(validity).signWith(key).compact();
+  }
+
+  public Claims getClaimsFromExpiredToken(String token) {
+    try {
+      return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
     }
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/util/JwtTokenProvider.java
@@ -92,18 +92,4 @@ public class JwtTokenProvider {
 
     return Jwts.builder().claims(claims).issuedAt(now).expiration(validity).signWith(key).compact();
   }
-
-  public Claims getClaimsFromExpiredToken(String token) {
-    try {
-      return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
-    } catch (ExpiredJwtException e) {
-      return e.getClaims();
-    } catch (io.jsonwebtoken.security.SecurityException
-        | MalformedJwtException
-        | UnsupportedJwtException
-        | IllegalArgumentException e) {
-      throw new com.example.picknwhip_be.global.apiPayload.exception.GeneralException(
-          com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode.INVALID_TOKEN);
-    }
-  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,6 +51,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity: 3600000 # 1시간 (단위: ms)
+  refresh-token-validity: 1209600000 # 14일 (단위: ms)
 
 springdoc:
   api-docs:

--- a/src/main/resources/db/migration/V24__create_refresh_token_table.sql
+++ b/src/main/resources/db/migration/V24__create_refresh_token_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE refresh_token (
+                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               token VARCHAR(255) NOT NULL UNIQUE,
+                               user_id BIGINT NOT NULL,
+                               expiry_date DATETIME(6) NOT NULL,
+                               created_at DATETIME(6) NOT NULL,
+                               updated_at DATETIME(6) NOT NULL,
+                               CONSTRAINT fk_refresh_token_user FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+-- 검색 성능 향상을 위해 인덱스 추가
+CREATE INDEX idx_refresh_token_value ON refresh_token(token);

--- a/src/main/resources/db/migration/V24__create_refresh_token_table.sql
+++ b/src/main/resources/db/migration/V24__create_refresh_token_table.sql
@@ -1,12 +1,9 @@
 CREATE TABLE refresh_token (
                                id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                               token VARCHAR(255) NOT NULL UNIQUE,
-                               user_id BIGINT NOT NULL,
+                               token VARCHAR(512) NOT NULL UNIQUE,
+                               user_id BIGINT NOT NULL UNIQUE,
                                expiry_date DATETIME(6) NOT NULL,
                                created_at DATETIME(6) NOT NULL,
                                updated_at DATETIME(6) NOT NULL,
                                CONSTRAINT fk_refresh_token_user FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
-
--- 검색 성능 향상을 위해 인덱스 추가
-CREATE INDEX idx_refresh_token_value ON refresh_token(token);


### PR DESCRIPTION
## 💡 Issue
- Close #203

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 리프레시토큰 발급
- 토큰 만료 시 무중단으로 토큰 재발급 가능

## 🛠️ Changes
- [x] 리프레시 토큰 RDB로 저장해서 토큰 정보를 데이터베이스에서 관리
- [x] JwtTokenProvider에서 액세스 토큰과 리프레시 토큰을 동시에 생성
- [x] 로그인 성공 시 리프레시 토큰을 생성하여 DB에 저장하고, 보안을 위해 클라이언트의 HttpOnly 쿠키로 전달
- [x] 토큰 재발급 API 추가
- [x] 리프레시 토큰 테이블 생성을 위한 V24 마이그레이션 SQL 파일 추가

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?