### PR TITLE
[FIX/#217]디자인 갤러리 상세조회 응답 수정

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/custom/entity/OrderDraft.java
+++ b/src/main/java/com/example/picknwhip_be/domain/custom/entity/OrderDraft.java
@@ -61,6 +61,9 @@ public class OrderDraft extends BaseEntity {
   @Column(name = "reference_image_url")
   private String referenceImageUrl;
 
+  @Column(name = "lettering_color")
+  private String letteringColor;
+
   @Builder.Default
   @OneToMany(mappedBy = "orderDraft", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<OrderDraftItem> items = new ArrayList<>();

--- a/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
@@ -61,6 +61,18 @@ public class DesignConverter {
         .letteringText(design.getLetteringText())
         .letteringAlignment(design.getLetteringAlignment())
         .letteringLineCount(design.getLetteringLineCount())
+        .letteringColor(design.getLetteringColor())
+        .availOptions(
+            design.getAvailOptions().stream()
+                .map(
+                    avail ->
+                        DesignResDTO.AvailOptionDTO.builder()
+                            .category(avail.getCustomOption().getCategory())
+                            .name(avail.getCustomOption().getOptionName())
+                            .price(avail.getCustomOption().getAdditionalPrice())
+                            .colorCode(avail.getCustomOption().getColorRgbCode())
+                            .build())
+                .toList())
         .keywords(design.getKeywords().stream().map(Style::getLabel).toList())
         .toppings(toppings)
         .options(options)

--- a/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/converter/DesignConverter.java
@@ -6,6 +6,7 @@ import com.example.picknwhip_be.domain.design.dto.res.DesignResDTO;
 import com.example.picknwhip_be.domain.design.entity.DesignGallery;
 import com.example.picknwhip_be.domain.design.entity.mapping.DesignOption;
 import com.example.picknwhip_be.domain.design.enums.Style;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,7 +34,8 @@ public class DesignConverter {
 
   public static DesignResDTO.GetDesignDetailDTO toDesignDetailDTO(DesignGallery design) {
 
-    List<DesignOption> rawOptions = design.getOptions() != null ? design.getOptions() : List.of();
+    Collection<DesignOption> rawOptions =
+        design.getOptions() != null ? design.getOptions() : List.of();
 
     Map<Boolean, List<DesignOption>> partitionedOptions =
         rawOptions.stream().collect(Collectors.partitioningBy(item -> item.getPositionX() != null));

--- a/src/main/java/com/example/picknwhip_be/domain/design/dto/res/DesignResDTO.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/dto/res/DesignResDTO.java
@@ -3,6 +3,7 @@ package com.example.picknwhip_be.domain.design.dto.res;
 import com.example.picknwhip_be.domain.custom.dto.res.CustomResDTO;
 import com.example.picknwhip_be.domain.order.entity.enums.LetteringAlignment;
 import com.example.picknwhip_be.domain.order.entity.enums.LetteringLineCount;
+import com.example.picknwhip_be.domain.shop.entity.enums.OptionCategory;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -47,10 +48,23 @@ public class DesignResDTO {
     private String letteringText;
     private LetteringLineCount letteringLineCount;
     private LetteringAlignment letteringAlignment;
+    private String letteringColor;
+
+    private List<AvailOptionDTO> availOptions;
     private List<String> keywords;
 
     private List<CustomResDTO.Topping> toppings;
     private List<CustomResDTO.Option> options;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class AvailOptionDTO {
+    private OptionCategory category;
+    private String name;
+    private String colorCode;
+    private int price;
   }
 
   @Builder

--- a/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
@@ -1,5 +1,6 @@
 package com.example.picknwhip_be.domain.design.entity;
 
+import com.example.picknwhip_be.domain.design.entity.mapping.AvailOption;
 import com.example.picknwhip_be.domain.design.entity.mapping.DesignOption;
 import com.example.picknwhip_be.domain.design.enums.Purpose;
 import com.example.picknwhip_be.domain.design.enums.Style;
@@ -59,6 +60,12 @@ public class DesignGallery {
   @Enumerated(EnumType.STRING)
   @Column(name = "lettering_alignment")
   private LetteringAlignment letteringAlignment;
+
+  @Column(name = "lettering_color")
+  private String letteringColor;
+
+  @OneToMany(mappedBy = "designGallery", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<AvailOption> availOptions = new ArrayList<>();
 
   @ElementCollection
   @CollectionTable(

--- a/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/entity/DesignGallery.java
@@ -9,10 +9,7 @@ import com.example.picknwhip_be.domain.order.entity.enums.LetteringLineCount;
 import com.example.picknwhip_be.domain.shop.entity.Shop;
 import com.example.picknwhip_be.domain.shop.entity.ShopCakeSize;
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import lombok.*;
 
 @Entity
@@ -65,7 +62,7 @@ public class DesignGallery {
   private String letteringColor;
 
   @OneToMany(mappedBy = "designGallery", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<AvailOption> availOptions = new ArrayList<>();
+  private Set<AvailOption> availOptions = new LinkedHashSet<>();
 
   @ElementCollection
   @CollectionTable(
@@ -86,5 +83,5 @@ public class DesignGallery {
 
   @OneToMany(mappedBy = "designGallery", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
-  private List<DesignOption> options = new ArrayList<>();
+  private Set<DesignOption> options = new HashSet<>();
 }

--- a/src/main/java/com/example/picknwhip_be/domain/design/entity/mapping/AvailOption.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/entity/mapping/AvailOption.java
@@ -1,0 +1,34 @@
+package com.example.picknwhip_be.domain.design.entity.mapping;
+
+import com.example.picknwhip_be.domain.design.entity.DesignGallery;
+import com.example.picknwhip_be.domain.shop.entity.CustomOption;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "avail_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AvailOption {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "avail_option_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "design_id")
+  private DesignGallery designGallery;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "custom_option_id")
+  private CustomOption customOption;
+
+  @Builder
+  public AvailOption(DesignGallery designGallery, CustomOption customOption) {
+    this.designGallery = designGallery;
+    this.customOption = customOption;
+  }
+}

--- a/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/repository/DesignGalleryRepository.java
@@ -9,7 +9,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface DesignGalleryRepository
     extends JpaRepository<DesignGallery, Long>, DesignGalleryRepositoryCustom {
 
-  @EntityGraph(attributePaths = {"options", "options.customOption", "shopCakeSize", "keywords"})
+  @EntityGraph(
+      attributePaths = {
+        "options",
+        "options.customOption",
+        "shopCakeSize",
+        "keywords",
+        "availOptions",
+        "availOptions.customOption"
+      })
   Optional<DesignGallery> findDesignGalleryById(Long id);
 
   @EntityGraph(attributePaths = {"keywords"})

--- a/src/main/java/com/example/picknwhip_be/domain/home/service/HomePopularDesignServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/home/service/HomePopularDesignServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.picknwhip_be.domain.home.exception.HomeException;
 import com.example.picknwhip_be.domain.home.exception.code.HomeErrorCode;
 import com.example.picknwhip_be.domain.home.repository.PopularDesignRankingRepository;
 import com.example.picknwhip_be.domain.shop.entity.enums.OptionCategory;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -112,7 +113,7 @@ public class HomePopularDesignServiceImpl implements HomePopularDesignService {
         .orElse(null);
   }
 
-  private String findOptionName(List<DesignOption> options, OptionCategory category) {
+  private String findOptionName(Collection<DesignOption> options, OptionCategory category) {
     if (options == null || options.isEmpty()) return "선택 안함";
 
     return options.stream()

--- a/src/main/resources/db/migration/V25__update_design_and_order.sql
+++ b/src/main/resources/db/migration/V25__update_design_and_order.sql
@@ -1,0 +1,17 @@
+ALTER TABLE design_gallery
+    ADD COLUMN lettering_color VARCHAR(30) COMMENT '레터링 색상 코드';
+
+ALTER TABLE orders_drafts
+    ADD COLUMN lettering_color VARCHAR(30) COMMENT '레터링 색상 코드';
+
+CREATE TABLE IF NOT EXISTS avail_option (
+                                            avail_option_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                            design_id BIGINT NOT NULL,
+                                            custom_option_id BIGINT NOT NULL,
+
+                                            CONSTRAINT fk_avail_option_design
+                                            FOREIGN KEY (design_id) REFERENCES design_gallery (id) ON DELETE CASCADE,
+
+    CONSTRAINT fk_avail_option_custom
+    FOREIGN KEY (custom_option_id) REFERENCES custom_options (id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/seed/local/R__seed_local_design_gallery_edit.sql
+++ b/src/main/resources/db/seed/local/R__seed_local_design_gallery_edit.sql
@@ -1,0 +1,151 @@
+/* ======================================================
+   1. 기존 design_options 좌표값 보정 (0 -> NULL)
+====================================================== */
+UPDATE design_options SET position_x = NULL WHERE position_x = 0 OR position_x = 0.0;
+UPDATE design_options SET position_y = NULL WHERE position_y = 0 OR position_y = 0.0;
+
+/* ======================================================
+   2. 기존 테스트 데이터 초기화 (충돌 방지용)
+   - 자식 테이블부터 먼저 삭제해야 외래 키 에러가 발생하지 않습니다.
+====================================================== */
+-- 자식 1: 키워드 및 매핑 테이블 삭제
+DELETE FROM design_gallery_keywords WHERE design_gallery_id IN (11, 12, 13, 14);
+DELETE FROM design_options WHERE design_id IN (11, 12, 13, 14);
+DELETE FROM avail_option WHERE design_id IN (11, 12, 13, 14);
+
+-- 자식 2: 부모 테이블 삭제
+DELETE FROM design_gallery WHERE id IN (11, 12, 13, 14);
+DELETE FROM custom_options WHERE id BETWEEN 101 AND 140;
+DELETE FROM shop_cake_sizes WHERE size_id BETWEEN 11 AND 18;
+
+/* ======================================================
+   3. 부모 가게(shops) 데이터 생성
+====================================================== */
+INSERT INTO shops (
+    shop_id, owner_id, shop_name, phone, address, district, location,
+    average_rating, min_price, max_price, status, verification_status, description,
+    pickup_time_guide, day_order_guide, parking_guide,
+    payment_notice, precaution_notice, prepayment, chat_nickname, created_at
+) VALUES
+      (11, 2, '레망도레 광화문점', '02-777-1234', '서울 중구 무교로 17 무교빌딩 1-3층', '중구', ST_GeomFromText('POINT(37.5679 126.9787)', 4326), 4.7, 35000, 75000, 'ACTIVE', 'VERIFIED', '광화문 디저트', 2, 1, '무교빌딩 주차장', '현장 결제 가능', '3일 전 예약 필수', 15000, '레망도레', NOW(6)),
+      (12, 2, '카라멜솔티드', '02-777-5678', '서울 중구 을지로3길 19 1층', '중구', ST_GeomFromText('POINT(37.5667 126.9805)', 4326), 4.9, 28000, 60000, 'ACTIVE', 'VERIFIED', '솔티드 카라멜', 1, 1, '주차 협소', '예약금 100%', '당일 취소 불가', 28000, '카라멜솔티드', NOW(6)),
+      (13, 2, '곤트란쉐리에', '02-777-9012', '서울 중구 세종대로22길 16 1층', '중구', ST_GeomFromText('POINT(37.5664 126.9775)', 4326), 4.6, 40000, 90000, 'ACTIVE', 'VERIFIED', '프랑스 정통 베이커리', 3, 0, '공영 주차장', '카드 환영', '시간 엄수', 20000, '곤트란쉐리에', NOW(6)),
+      (14, 2, '더플라자호텔 블랑제리', '02-777-3456', '서울 중구 소공로 119 LL층', '중구', ST_GeomFromText('POINT(37.5649 126.9784)', 4326), 4.9, 60000, 150000, 'ACTIVE', 'VERIFIED', '프리미엄 케이크', 5, 0, '호텔 2시간 무료', '멤버십 적립', '1주일 전 문의', 50000, '블랑제리', NOW(6))
+    ON DUPLICATE KEY UPDATE shop_name = VALUES(shop_name);
+
+/* ======================================================
+   4. 가게별 케이크 사이즈 추가
+====================================================== */
+INSERT INTO shop_cake_sizes (size_id, shop_id, size_name, diameter, price) VALUES
+                                                                               (11, 11, '도시락', '10cm', 20000), (12, 11, '1호', '15cm', 35000),
+                                                                               (13, 12, '도시락', '10cm', 22000), (14, 12, '1호', '15cm', 38000),
+                                                                               (15, 13, '1호', '15cm', 40000), (16, 13, '2호', '18cm', 55000),
+                                                                               (17, 14, '1호', '15cm', 60000), (18, 14, '2호', '18cm', 80000);
+
+/* ======================================================
+   5. 커스텀 마스터 옵션 (custom_options)
+   - 카테고리별로 여러 개 생성 (RGB 코드 완벽 포함)
+====================================================== */
+INSERT INTO custom_options (id, shop_id, option_name, category, additional_price, color_rgb_code) VALUES
+                                                                                                      -- Shop 11 (레망도레)
+                                                                                                      (101, 11, '바닐라 시트', 'SHEET', 0, '#FFF8DC'),
+                                                                                                      (102, 11, '초코 시트', 'SHEET', 1000, '#8B4513'),
+                                                                                                      (103, 11, '우유 생크림', 'CREAM', 0, '#FFFFFF'),
+                                                                                                      (104, 11, '딸기 생크림', 'CREAM', 1500, '#FFC0CB'),
+                                                                                                      (105, 11, '화이트 아이싱', 'ICING', 0, '#FFFFFF'),
+                                                                                                      (106, 11, '핑크 아이싱', 'ICING', 2000, '#FFB6C1'),
+                                                                                                      (107, 11, '원형 쉐입', 'SHAPE', 0, '#FFFFFF'),
+                                                                                                      (108, 11, '하트 쉐입', 'SHAPE', 2000, '#FF69B4'),
+                                                                                                      (109, 11, '생딸기', 'TOPPING', 3000, NULL),
+                                                                                                      (110, 11, '마카롱 꼬끄', 'TOPPING', 4500, NULL),
+
+                                                                                                      -- Shop 12 (카라멜솔티드)
+                                                                                                      (111, 12, '레드벨벳 시트', 'SHEET', 2000, '#8B0000'),
+                                                                                                      (112, 12, '모카 시트', 'SHEET', 1500, '#A0522D'),
+                                                                                                      (113, 12, '크림치즈', 'CREAM', 1000, '#FFFAF0'),
+                                                                                                      (114, 12, '카라멜 크림', 'CREAM', 2500, '#D2691E'),
+                                                                                                      (115, 12, '아이보리 아이싱', 'ICING', 0, '#FFFFF0'),
+                                                                                                      (116, 12, '민트 아이싱', 'ICING', 2000, '#98FF98'),
+                                                                                                      (117, 12, '원형 쉐입', 'SHAPE', 0, '#FFFFFF'),
+                                                                                                      (118, 12, '사각 쉐입', 'SHAPE', 3000, '#FFFFFF'),
+                                                                                                      (119, 12, '오레오 쿠키', 'TOPPING', 2000, NULL),
+                                                                                                      (120, 12, '로투스 부스러기', 'TOPPING', 1500, NULL),
+
+                                                                                                      -- Shop 13 (곤트란쉐리에)
+                                                                                                      (121, 13, '얼그레이 시트', 'SHEET', 3000, '#D3B8AE'),
+                                                                                                      (122, 13, '플레인 시트', 'SHEET', 0, '#F5DEB3'),
+                                                                                                      (123, 13, '가나슈 크림', 'CREAM', 3500, '#3E2723'),
+                                                                                                      (124, 13, '요거트 크림', 'CREAM', 2000, '#F0FFF0'),
+                                                                                                      (125, 13, '블루 아이싱', 'ICING', 2000, '#87CEEB'),
+                                                                                                      (126, 13, '블랙 아이싱', 'ICING', 3000, '#000000'),
+                                                                                                      (127, 13, '원형 쉐입', 'SHAPE', 0, '#FFFFFF'),
+                                                                                                      (128, 13, '돔 쉐입', 'SHAPE', 4000, '#FFFFFF'),
+                                                                                                      (129, 13, '생블루베리', 'TOPPING', 4000, NULL),
+                                                                                                      (130, 13, '초코 진주', 'TOPPING', 2500, NULL),
+
+                                                                                                      -- Shop 14 (더플라자호텔)
+                                                                                                      (131, 14, '프리미엄 바닐라', 'SHEET', 5000, '#FFFACD'),
+                                                                                                      (132, 14, '블랙 카카오', 'SHEET', 5000, '#1A1A1A'),
+                                                                                                      (133, 14, '마스카포네 크림', 'CREAM', 4000, '#FFFFF0'),
+                                                                                                      (134, 14, '트러플 크림', 'CREAM', 8000, '#F5F5DC'),
+                                                                                                      (135, 14, '다크초코 아이싱', 'ICING', 3000, '#2F4F4F'),
+                                                                                                      (136, 14, '골드 아이싱', 'ICING', 7000, '#FFD700'),
+                                                                                                      (137, 14, '원형 쉐입', 'SHAPE', 0, '#FFFFFF'),
+                                                                                                      (138, 14, '2단 쉐입', 'SHAPE', 20000, '#FFFFFF'),
+                                                                                                      (139, 14, '왕관 장식', 'TOPPING', 15000, NULL),
+                                                                                                      (140, 14, '식용 생화', 'TOPPING', 12000, NULL);
+
+/* ======================================================
+   6. 디자인 갤러리 추가 (design_gallery)
+====================================================== */
+INSERT INTO design_gallery (
+    id, shop_id, shop_cake_size_id, design_name, base_price, description,
+    allergy_info, image_url, lettering_text, lettering_line_count,
+    lettering_alignment, lettering_color
+) VALUES
+      (11, 11, 12, '광화문 핑크 하트', 45000, '사랑스러운 핑크색 하트 케이크', '우유, 밀', 'https://example.com/11.jpg', '수고했어', 'ONE_LINE', 'CENTER', '#000000'),
+      (12, 12, 14, '단짠 카라멜 폭탄', 48000, '솔티드 카라멜', '우유, 밀', 'https://example.com/12.jpg', 'HBD', 'TWO_LINE', 'CENTER', '#FFFFFF'),
+      (13, 13, 15, '얼그레이 갸또', 55000, '진한 얼그레이', '우유, 밀', 'https://example.com/13.jpg', '사랑해', 'ONE_LINE', 'CURVE_UP', '#FF0000'),
+      (14, 14, 17, '플라자 블랙', 95000, '프리미엄 블랙 케이크', '우유, 견과류', 'https://example.com/14.jpg', 'Congrats', 'ONE_LINE', 'CURVE_UP_DOWN', '#FFD700');
+
+/* ======================================================
+   7. 갤러리 디자인에 적용된 찐 옵션 (design_options)
+   - 조건: 카테고리당 무조건 1개만! (SHEET 1, CREAM 1, ICING 1, SHAPE 1)
+   - TOPPING에만 X, Y 좌표 입력! (나머지는 NULL)
+====================================================== */
+INSERT INTO design_options (design_id, custom_option_id, position_x, position_y) VALUES
+                                                                                     -- Design 11: 바닐라시트 + 딸기크림 + 핑크아이싱 + 하트쉐입 + 생딸기
+                                                                                     (11, 101, NULL, NULL), (11, 104, NULL, NULL), (11, 106, NULL, NULL), (11, 108, NULL, NULL), (11, 109, 50.0, 50.0),
+
+                                                                                     -- Design 12: 레드벨벳 + 카라멜크림 + 민트아이싱 + 원형쉐입 + 로투스
+                                                                                     (12, 111, NULL, NULL), (12, 114, NULL, NULL), (12, 116, NULL, NULL), (12, 117, NULL, NULL), (12, 120, 40.0, 60.0),
+
+                                                                                     -- Design 13: 얼그레이 + 가나슈 + 블루아이싱 + 돔쉐입 + 생블루베리
+                                                                                     (13, 121, NULL, NULL), (13, 123, NULL, NULL), (13, 125, NULL, NULL), (13, 128, NULL, NULL), (13, 129, 30.0, 70.0),
+
+                                                                                     -- Design 14: 블랙카카오 + 마스카포네 + 다크초코아이싱 + 2단쉐입 + 왕관
+                                                                                     (14, 132, NULL, NULL), (14, 133, NULL, NULL), (14, 135, NULL, NULL), (14, 138, NULL, NULL), (14, 139, 50.0, 15.0);
+
+/* ======================================================
+   8. 선택 가능한 옵션 목록 (design_avail_options)
+   - 조건: 카테고리별로 여러 개 제공
+====================================================== */
+INSERT INTO avail_option (design_id, custom_option_id) VALUES
+                                                                   -- Design 11에서 유저가 고를 수 있는 옵션들 (시트 2종, 크림 2종, 아이싱 2종, 쉐입 2종, 토핑 2종 전부)
+                                                                   (11, 101), (11, 102), (11, 103), (11, 104), (11, 105), (11, 106), (11, 107), (11, 108), (11, 109), (11, 110),
+                                                                   -- Design 12
+                                                                   (12, 111), (12, 112), (12, 113), (12, 114), (12, 115), (12, 116), (12, 117), (12, 118), (12, 119), (12, 120),
+                                                                   -- Design 13
+                                                                   (13, 121), (13, 122), (13, 123), (13, 124), (13, 125), (13, 126), (13, 127), (13, 128), (13, 129), (13, 130),
+                                                                   -- Design 14
+                                                                   (14, 131), (14, 132), (14, 133), (14, 134), (14, 135), (14, 136), (14, 137), (14, 138), (14, 139), (14, 140);
+
+/* ======================================================
+   9. 키워드 매핑 (design_gallery_keywords)
+   - 필터링에 사용할 키워드(스타일/용도) 추가
+====================================================== */
+INSERT INTO design_gallery_keywords (design_gallery_id, keyword) VALUES
+                                                                      (11, 'GORGEOUS'), (11, 'MODERN'),
+                                                                      (12, 'LUXURY'), (12, 'MODERN'),
+                                                                      (13, 'LUXURY'), (13, 'GORGEOUS'),
+                                                                      (14, 'RED_VELVET'), (14, 'LOVELY');

--- a/src/main/resources/db/seed/local/R__seed_local_shop_keyword.sql
+++ b/src/main/resources/db/seed/local/R__seed_local_shop_keyword.sql
@@ -52,34 +52,3 @@ SELECT 2, @kw_xmas
     WHERE @kw_xmas IS NOT NULL
   AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=2 AND keyword_id=@kw_xmas);
 
--- shop 11: 레망도레 광화문점
-INSERT INTO shop_keyword_mapping (shop_id, keyword_id)
-SELECT 11, @kw_xmas
-    WHERE @kw_xmas IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=11 AND keyword_id=@kw_xmas);
-
-INSERT INTO shop_keyword_mapping (shop_id, keyword_id)
-SELECT 11, @kw_anniv
-    WHERE @kw_anniv IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=11 AND keyword_id=@kw_anniv);
-
-INSERT INTO shop_keyword_mapping (shop_id, keyword_id)
-SELECT 11, @kw_party
-    WHERE @kw_party IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=11 AND keyword_id=@kw_party);
-
--- shop 14: 더플라자호텔 블랑제리
-INSERT INTO shop_keyword_mapping (shop_id, keyword_id)
-SELECT 14, @kw_birthday
-    WHERE @kw_birthday IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=14 AND keyword_id=@kw_birthday);
-
-INSERT INTO shop_keyword_mapping (shop_id, keyword_id)
-SELECT 14, @kw_anniv
-    WHERE @kw_anniv IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=14 AND keyword_id=@kw_anniv);
-
-INSERT INTO shop_keyword_mapping (shop_id, keyword_id)
-SELECT 14, @kw_party
-    WHERE @kw_party IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM shop_keyword_mapping WHERE shop_id=14 AND keyword_id=@kw_party);


### PR DESCRIPTION
## 💡 Issue
- Close #217 
  (이슈 번호를 입력하면 PR이 머지될 때 이슈가 자동으로 닫힙니다)

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 디자인 갤러리 상세조회의 응답을 수정합니다
- seed를 수정합니다

## 🛠️ Changes
- [ ] 디자인갤러리당 커스텀 가능한 옵션을 표시하기 위해 custom_options와 design_gallery 사이의 매핑 테이블 추가
- [ ] 디자인갤러리의 텍스트 색상 컬럼 추가
- [ ] design_options를 set으로 추가 -> 이에 따라 List로 해당 컬럼을 받던 부분을 collection으로 수정하였습니다.
- [ ] seed로 shop id 11,12,13,14 / designgallery id 11,12,13,14 부분의 데이터를 정리하였습니다.

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [ ] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] develop 브랜치의 최신 사항을 pull 받았나요?
- [ ] 테스트(빌드)가 성공적으로 통과했나요?