### PR TITLE
[BUG] 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
@@ -13,6 +13,7 @@ import com.example.picknwhip_be.domain.user.repository.UserRepository;
 import com.example.picknwhip_be.domain.user.repository.UserWithdrawalRepository;
 import com.example.picknwhip_be.domain.user.repository.WithdrawalReasonItemRepository;
 import com.example.picknwhip_be.global.apiPayload.code.AuthErrorCode;
+import com.example.picknwhip_be.global.apiPayload.code.GeneralErrorCode;
 import com.example.picknwhip_be.global.apiPayload.exception.GeneralException;
 import com.example.picknwhip_be.global.apiPayload.util.JwtTokenProvider;
 import java.time.Duration;
@@ -157,6 +158,10 @@ public class UserCommandServiceImpl implements UserCommandService {
   @Override
   @Transactional
   public void withdrawMember(Long userId, UserReqDTO.WithdrawalDTO request) {
+    if (request == null) {
+      throw new GeneralException(GeneralErrorCode.BAD_REQUEST);
+    }
+
     User user =
         userRepository
             .findById(userId)
@@ -164,11 +169,14 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     // 탈퇴 기록 생성
     UserWithdrawal withdrawal =
-        UserWithdrawal.builder().user(user).feedback(request.getFeedback()).build();
-    userWithdrawalRepository.save(withdrawal);
+        UserWithdrawal.builder()
+            .user(user)
+            .feedback(request.getFeedback() != null ? request.getFeedback() : "")
+            .build();
+    userWithdrawalRepository.saveAndFlush(withdrawal);
 
     // 선택한 사유 저장
-    if (request.getReasons() != null) {
+    if (request.getReasons() != null && !request.getReasons().isEmpty()) {
       List<WithdrawalReasonItem> items =
           request.getReasons().stream()
               .map(
@@ -181,7 +189,8 @@ public class UserCommandServiceImpl implements UserCommandService {
       reasonItemRepository.saveAll(items);
     }
 
-    // 직접 상태를 변경하는 대신 Repository의 delete를 호출
+    // 리프레시 토큰 삭제 후 회원 soft delete
+    refreshTokenRepository.deleteByUserId(userId);
     userRepository.delete(user);
   }
 


### PR DESCRIPTION
## 💡 Issue
- Close #229 

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [x] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 회원 탈퇴 시 500 에러가 떠서 응답 에러 코드 추가했는데도 불구하고 500 에러 발생
- request null 처리 추가
- UserWithdrawal 저장 부분을 save() → saveAndFlush() 로 변경해서 DB에 바로 반영 후 withdrawal_id 사용
- 탈퇴 시 리프레시 토큰 삭제함

## 🛠️ Changes
- [ ] 수정된 주요 로직 1
- [ ] 수정된 주요 로직 2

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?