### PR TITLE
[BUG] 사용자 탈퇴 연관 관계 수정

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/controller/UserRestController.java
@@ -33,7 +33,7 @@ public class UserRestController {
   private final UserCommandService userCommandService;
 
   @Value("${jwt.refresh-token-validity:1209600000}")
-  private long refreshTokenValidityInMilliseconds; // 14일 기본값 (ms)
+  private long refreshTokenValidityInMilliseconds;
 
   @Operation(
       summary = "리프레시토큰 발급 API",
@@ -97,12 +97,9 @@ public class UserRestController {
   public ApiResponse<String> createLogout(
       @ExtractPayload Long userId, HttpServletRequest request, HttpServletResponse response) {
     try {
-      // 카카오 서버 로그아웃 + DB 리프레시 토큰 삭제
       userCommandService.logout(userId);
     } finally {
-      // 리프레시 토큰 쿠키 삭제
       CookieUtils.deleteCookie(request, response, "refreshToken");
-      // 서버 세션 무효화
       HttpSession session = request.getSession(false);
       if (session != null) {
         session.invalidate();

--- a/src/main/java/com/example/picknwhip_be/domain/user/entity/UserWithdrawal.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/entity/UserWithdrawal.java
@@ -1,8 +1,16 @@
 package com.example.picknwhip_be.domain.user.entity;
 
 import com.example.picknwhip_be.global.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -15,9 +23,8 @@ public class UserWithdrawal extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long withdrawalId;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
 
   @Column(columnDefinition = "TEXT")
   private String feedback;

--- a/src/main/java/com/example/picknwhip_be/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/repository/RefreshTokenRepository.java
@@ -3,11 +3,16 @@ package com.example.picknwhip_be.domain.user.repository;
 import com.example.picknwhip_be.domain.user.entity.RefreshToken;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
   Optional<RefreshToken> findByToken(String token);
 
   Optional<RefreshToken> findByUserId(Long userId);
 
-  void deleteByUserId(Long userId);
+  @Modifying
+  @Query("DELETE FROM RefreshToken r WHERE r.userId = :userId")
+  void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/user/service/command/UserCommandServiceImpl.java
@@ -170,7 +170,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     // 탈퇴 기록 생성
     UserWithdrawal withdrawal =
         UserWithdrawal.builder()
-            .user(user)
+            .userId(user.getUserId())
             .feedback(request.getFeedback() != null ? request.getFeedback() : "")
             .build();
     userWithdrawalRepository.saveAndFlush(withdrawal);

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/JwtAuthenticationFilter.java
@@ -50,12 +50,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
 
   private String resolveToken(HttpServletRequest request) {
-    // 1) Authorization 헤더 (Bearer) 우선
     String bearerToken = request.getHeader("Authorization");
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
       return bearerToken.substring(7);
     }
-    // 2) HttpOnly 쿠키 (OAuth2 로그인 후 리다이렉트 시 설정된 액세스 토큰)
     if (request.getCookies() != null) {
       for (jakarta.servlet.http.Cookie cookie : request.getCookies()) {
         if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/SecurityConfig.java
@@ -23,9 +23,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; // 주입 확인!
-  private final CustomOAuth2UserService customOAuth2UserService; // 주입
-  private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler; // 주입
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
   private final JwtTokenProvider jwtTokenProvider;
 
   @Value("${app.frontend-url}")

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -30,7 +30,6 @@ public class GeneralExceptionAdvice {
         .body(ApiResponse.onFailure(code, "데이터 처리 중 오류가 발생했습니다. (참조 ID 등을 확인하세요)"));
   }
 
-  /** 인증 없이 접근 시 @ExtractPayload에서 발생 → 401 반환 (500 방지) */
   @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
   public ResponseEntity<ApiResponse<Void>> handleAuthRelated(RuntimeException ex) {
     if (ex.getMessage() != null
@@ -43,7 +42,6 @@ public class GeneralExceptionAdvice {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<String>> handleException(Exception ex) {
-
     log.error("Unexpected Error Occurred: ", ex);
     BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
     return ResponseEntity.status(code.getStatus()).body(ApiResponse.onFailure(code, null));


### PR DESCRIPTION
## 💡 Issue
- Close #232
## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [x] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 사용자 탈퇴 시 계속해서 500 오류가 나서 UserWithdrawal와 User의 연관 관계를 끊고, userId 값만 저장하도록 수정

## 🛠️ Changes
- [x] UserWithdrawa 엔티티

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?