### PR TITLE
[FEAT/#250] 내 현재 위치 외부 API 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     // Spatial 기능 추가 (Point 타입 사용을 위해)
     implementation 'org.hibernate.orm:hibernate-spatial'
 	runtimeOnly 'com.h2database:h2'
+// kakaoLocalClient import 위해
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
 
     // AWS SDK v2 (S3)
     implementation platform('software.amazon.awssdk:bom:2.41.10')

--- a/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/design/service/query/DesignQueryServiceImpl.java
@@ -12,14 +12,18 @@ import com.example.picknwhip_be.domain.favorite.repository.FavoriteDesignReposit
 import com.example.picknwhip_be.domain.shop.exception.ShopException;
 import com.example.picknwhip_be.domain.shop.exception.code.ShopErrorCode;
 import com.example.picknwhip_be.domain.shop.repository.ShopRepository;
+import com.example.picknwhip_be.global.infra.kakao.client.KakaoLocalClient;
+import com.example.picknwhip_be.global.infra.kakao.dto.KakaoCoord2RegionResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -28,6 +32,7 @@ public class DesignQueryServiceImpl implements DesignQueryService {
   private final DesignGalleryRepository designRepository;
   private final FavoriteDesignRepository favoriteDesignRepository;
   private final ShopRepository shopRepository;
+  private final KakaoLocalClient kakaoLocalClient;
 
   @Override
   @Transactional(readOnly = true)
@@ -95,7 +100,9 @@ public class DesignQueryServiceImpl implements DesignQueryService {
 
     List<Style> categories = parseCategory(categoryStr);
     validateSortType(sortType);
-    String currentDistrict = reverseGeocode(lat, lon);
+    RegionResult region = resolveRegion(lat, lon);
+    String currentDistrict = region.district(); // 예: "마포구"
+    String currentRegionText = region.currentText(); // 예: "현재 위치: 서울시 마포구"
 
     Pageable pageable = PageRequest.of(page, 4);
     Page<DesignResDTO.GalleryItemDTO> resultPage =
@@ -103,7 +110,7 @@ public class DesignQueryServiceImpl implements DesignQueryService {
             categories, sortType, currentDistrict, lat, lon, seed, userId, pageable);
 
     return DesignResDTO.GalleryListDTO.builder()
-        .currentRegion("서울시 " + (currentDistrict != null ? currentDistrict : "전체"))
+        .currentRegion(currentRegionText)
         .designs(resultPage.getContent())
         .totalPage(resultPage.getTotalPages())
         .totalElements(resultPage.getTotalElements())
@@ -111,6 +118,43 @@ public class DesignQueryServiceImpl implements DesignQueryService {
         .isLast(resultPage.isLast())
         .build();
   }
+
+  // 좌표 -> "시/구" 텍스트 + district(구) 추출
+  private RegionResult resolveRegion(Double lat, Double lon) {
+    try {
+      KakaoCoord2RegionResponse.Document doc = kakaoLocalClient.coordToRegion(lat, lon);
+      if (doc == null) {
+        return new RegionResult(null, "현재 위치: 전체"); // fallback
+      }
+
+      String region1 = shortenRegion1(doc.region_1depth_name()); // "서울특별시" -> "서울시"
+      String region2 = doc.region_2depth_name(); // "마포구"
+
+      String district = (region2 == null || region2.isBlank()) ? null : region2;
+
+      String text =
+          (district == null)
+              ? "현재 위치: " + (region1 != null ? region1 : "전체")
+              : "현재 위치: " + (region1 != null ? region1 + " " + district : district);
+
+      return new RegionResult(district, text);
+
+    } catch (Exception e) {
+      log.warn("Kakao reverse-geocode failed. lat={}, lon={}, reason={}", lat, lon, e.getMessage());
+      // 홈이 죽지 않게 fallback
+      return new RegionResult(null, "현재 위치: 전체");
+    }
+  }
+
+  private String shortenRegion1(String region1) {
+    if (region1 == null) return null;
+    if (region1.startsWith("서울")) return "서울시";
+    if (region1.endsWith("특별시")) return region1.replace("특별시", "시");
+    if (region1.endsWith("광역시")) return region1.replace("광역시", "시");
+    return region1;
+  }
+
+  private record RegionResult(String district, String currentText) {}
 
   private void validateCoordinate(Double lat, Double lon) {
     if (lat == null || lon == null) {

--- a/src/main/java/com/example/picknwhip_be/global/apiPayload/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/apiPayload/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.example.picknwhip_be.global.apiPayload.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/config/RestTemplateConfig.java
@@ -1,4 +1,4 @@
-package com.example.picknwhip_be.global.apiPayload.config;
+package com.example.picknwhip_be.global.config;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -8,8 +8,8 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
 
-    @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.build();
-    }
+  @Bean
+  public RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder.build();
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/picknwhip_be/global/config/RestTemplateConfig.java
@@ -1,15 +1,32 @@
 package com.example.picknwhip_be.global.config;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
 
   @Bean
-  public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
+  public RestTemplate restTemplate() {
+
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setConnectTimeout(Timeout.ofSeconds(5))
+            .setResponseTimeout(Timeout.ofSeconds(5))
+            .build();
+
+    CloseableHttpClient httpClient =
+        HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+
+    HttpComponentsClientHttpRequestFactory factory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+
+    return new RestTemplate(factory);
   }
 }

--- a/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
@@ -31,16 +31,21 @@ public class KakaoLocalClient {
             .build()
             .toUriString();
 
-    // 환경변수/프로퍼티에 공백/개행이 섞이는 경우가 진짜 흔함 → 무조건 trim
     String appKey = (kakaoRestApiKey == null) ? null : kakaoRestApiKey.trim();
 
-    // 키 원문 노출 금지: 길이만 비교(원본 vs trim)
+    // 키 누락/비어있으면 카카오 호출 전에 즉시 실패시키기
+    if (appKey == null || appKey.isBlank()) {
+      throw new IllegalStateException(
+          "Kakao REST API key is missing. Please set property 'kakao.rest-api-key' (e.g., env KAKAO_CLIENT_ID).");
+    }
+
+    // 키 원문 노출 금지: 길이만 로그
     int rawLen = (kakaoRestApiKey == null) ? -1 : kakaoRestApiKey.length();
-    int trimmedLen = (appKey == null) ? -1 : appKey.length();
+    int trimmedLen = appKey.length();
     log.info("[KakaoLocalClient] restApiKey rawLen={}, trimmedLen={}", rawLen, trimmedLen);
 
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + appKey); // 공백 포함 정확히
+    headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + appKey);
 
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 

--- a/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
@@ -16,50 +16,55 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class KakaoLocalClient {
 
-    private final RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
-    @Value("${kakao.rest-api-key}")
-    private String kakaoRestApiKey;
+  @Value("${kakao.rest-api-key}")
+  private String kakaoRestApiKey;
 
-    public KakaoCoord2RegionResponse.Document coordToRegion(Double lat, Double lon) {
+  public KakaoCoord2RegionResponse.Document coordToRegion(Double lat, Double lon) {
 
-        String url = UriComponentsBuilder
-                .fromHttpUrl("https://dapi.kakao.com/v2/local/geo/coord2regioncode.json")
-                .queryParam("x", lon) // x=경도
-                .queryParam("y", lat) // y=위도
-                .build()
-                .toUriString();
+    String url =
+        UriComponentsBuilder.fromHttpUrl(
+                "https://dapi.kakao.com/v2/local/geo/coord2regioncode.json")
+            .queryParam("x", lon) // x=경도
+            .queryParam("y", lat) // y=위도
+            .build()
+            .toUriString();
 
-        // 환경변수/프로퍼티에 공백/개행이 섞이는 경우가 진짜 흔함 → 무조건 trim
-        String appKey = (kakaoRestApiKey == null) ? null : kakaoRestApiKey.trim();
+    // 환경변수/프로퍼티에 공백/개행이 섞이는 경우가 진짜 흔함 → 무조건 trim
+    String appKey = (kakaoRestApiKey == null) ? null : kakaoRestApiKey.trim();
 
-        // 키 원문 노출 금지: 길이만 비교(원본 vs trim)
-        int rawLen = (kakaoRestApiKey == null) ? -1 : kakaoRestApiKey.length();
-        int trimmedLen = (appKey == null) ? -1 : appKey.length();
-        log.info("[KakaoLocalClient] restApiKey rawLen={}, trimmedLen={}", rawLen, trimmedLen);
+    // 키 원문 노출 금지: 길이만 비교(원본 vs trim)
+    int rawLen = (kakaoRestApiKey == null) ? -1 : kakaoRestApiKey.length();
+    int trimmedLen = (appKey == null) ? -1 : appKey.length();
+    log.info("[KakaoLocalClient] restApiKey rawLen={}, trimmedLen={}", rawLen, trimmedLen);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + appKey); // 공백 포함 정확히
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + appKey); // 공백 포함 정확히
 
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        try {
-            ResponseEntity<KakaoCoord2RegionResponse> response =
-                    restTemplate.exchange(url, HttpMethod.GET, entity, KakaoCoord2RegionResponse.class);
+    try {
+      ResponseEntity<KakaoCoord2RegionResponse> response =
+          restTemplate.exchange(url, HttpMethod.GET, entity, KakaoCoord2RegionResponse.class);
 
-            KakaoCoord2RegionResponse body = response.getBody();
-            if (body == null || body.documents() == null || body.documents().isEmpty()) return null;
+      KakaoCoord2RegionResponse body = response.getBody();
+      if (body == null || body.documents() == null || body.documents().isEmpty()) return null;
 
-            // "H"(행정동) 우선 선택
-            return body.documents().stream()
-                    .sorted(Comparator.comparing(
-                            (KakaoCoord2RegionResponse.Document d) -> !"H".equals(d.region_type())))
-                    .findFirst()
-                    .orElse(null);
+      // "H"(행정동) 우선 선택
+      return body.documents().stream()
+          .sorted(
+              Comparator.comparing(
+                  (KakaoCoord2RegionResponse.Document d) -> !"H".equals(d.region_type())))
+          .findFirst()
+          .orElse(null);
 
-        } catch (HttpStatusCodeException e) {
-            log.warn("[KakaoLocalClient] FAILED status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
-            throw e;
-        }
+    } catch (HttpStatusCodeException e) {
+      log.warn(
+          "[KakaoLocalClient] FAILED status={}, body={}",
+          e.getStatusCode(),
+          e.getResponseBodyAsString());
+      throw e;
     }
+  }
 }

--- a/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
@@ -1,0 +1,45 @@
+package com.example.picknwhip_be.global.infra.kakao.client;
+
+import com.example.picknwhip_be.global.infra.kakao.dto.KakaoCoord2RegionResponse;
+import java.util.Comparator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoLocalClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.rest-api-key}")
+    private String kakaoRestApiKey;
+
+    public KakaoCoord2RegionResponse.Document coordToRegion(Double lat, Double lon) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl("https://dapi.kakao.com/v2/local/geo/coord2regioncode.json")
+                .queryParam("x", lon) // Kakao는 x=경도(lon), y=위도(lat)
+                .queryParam("y", lat)
+                .build()
+                .toUriString();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoRestApiKey); // client-id(REST API 키) 사용
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoCoord2RegionResponse> response =
+                restTemplate.exchange(url, HttpMethod.GET, entity, KakaoCoord2RegionResponse.class);
+
+        KakaoCoord2RegionResponse body = response.getBody();
+        if (body == null || body.documents() == null || body.documents().isEmpty()) return null;
+
+        // "H"(행정동)을 우선 선택
+        return body.documents().stream()
+                .sorted(Comparator.comparing((KakaoCoord2RegionResponse.Document d) -> !"H".equals(d.region_type())))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/kakao/client/KakaoLocalClient.java
@@ -3,12 +3,15 @@ package com.example.picknwhip_be.global.infra.kakao.client;
 import com.example.picknwhip_be.global.infra.kakao.dto.KakaoCoord2RegionResponse;
 import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoLocalClient {
@@ -19,27 +22,44 @@ public class KakaoLocalClient {
     private String kakaoRestApiKey;
 
     public KakaoCoord2RegionResponse.Document coordToRegion(Double lat, Double lon) {
+
         String url = UriComponentsBuilder
                 .fromHttpUrl("https://dapi.kakao.com/v2/local/geo/coord2regioncode.json")
-                .queryParam("x", lon) // Kakao는 x=경도(lon), y=위도(lat)
-                .queryParam("y", lat)
+                .queryParam("x", lon) // x=경도
+                .queryParam("y", lat) // y=위도
                 .build()
                 .toUriString();
 
+        // 환경변수/프로퍼티에 공백/개행이 섞이는 경우가 진짜 흔함 → 무조건 trim
+        String appKey = (kakaoRestApiKey == null) ? null : kakaoRestApiKey.trim();
+
+        // 키 원문 노출 금지: 길이만 비교(원본 vs trim)
+        int rawLen = (kakaoRestApiKey == null) ? -1 : kakaoRestApiKey.length();
+        int trimmedLen = (appKey == null) ? -1 : appKey.length();
+        log.info("[KakaoLocalClient] restApiKey rawLen={}, trimmedLen={}", rawLen, trimmedLen);
+
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "KakaoAK " + kakaoRestApiKey); // client-id(REST API 키) 사용
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + appKey); // 공백 포함 정확히
+
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<KakaoCoord2RegionResponse> response =
-                restTemplate.exchange(url, HttpMethod.GET, entity, KakaoCoord2RegionResponse.class);
+        try {
+            ResponseEntity<KakaoCoord2RegionResponse> response =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, KakaoCoord2RegionResponse.class);
 
-        KakaoCoord2RegionResponse body = response.getBody();
-        if (body == null || body.documents() == null || body.documents().isEmpty()) return null;
+            KakaoCoord2RegionResponse body = response.getBody();
+            if (body == null || body.documents() == null || body.documents().isEmpty()) return null;
 
-        // "H"(행정동)을 우선 선택
-        return body.documents().stream()
-                .sorted(Comparator.comparing((KakaoCoord2RegionResponse.Document d) -> !"H".equals(d.region_type())))
-                .findFirst()
-                .orElse(null);
+            // "H"(행정동) 우선 선택
+            return body.documents().stream()
+                    .sorted(Comparator.comparing(
+                            (KakaoCoord2RegionResponse.Document d) -> !"H".equals(d.region_type())))
+                    .findFirst()
+                    .orElse(null);
+
+        } catch (HttpStatusCodeException e) {
+            log.warn("[KakaoLocalClient] FAILED status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/example/picknwhip_be/global/infra/kakao/dto/KakaoCoord2RegionResponse.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/kakao/dto/KakaoCoord2RegionResponse.java
@@ -6,12 +6,11 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record KakaoCoord2RegionResponse(List<Document> documents) {
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Document(
-            String region_type,        // "H"(행정동) / "B"(법정동)
-            String region_1depth_name, // 시/도
-            String region_2depth_name, // 시/군/구 (서울이면 "마포구")
-            String region_3depth_name, // 읍/면/동
-            String address_name
-    ) {}
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Document(
+      String region_type, // "H"(행정동) / "B"(법정동)
+      String region_1depth_name, // 시/도
+      String region_2depth_name, // 시/군/구 (서울이면 "마포구")
+      String region_3depth_name, // 읍/면/동
+      String address_name) {}
 }

--- a/src/main/java/com/example/picknwhip_be/global/infra/kakao/dto/KakaoCoord2RegionResponse.java
+++ b/src/main/java/com/example/picknwhip_be/global/infra/kakao/dto/KakaoCoord2RegionResponse.java
@@ -1,0 +1,17 @@
+package com.example.picknwhip_be.global.infra.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoCoord2RegionResponse(List<Document> documents) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Document(
+            String region_type,        // "H"(행정동) / "B"(법정동)
+            String region_1depth_name, // 시/도
+            String region_2depth_name, // 시/군/구 (서울이면 "마포구")
+            String region_3depth_name, // 읍/면/동
+            String address_name
+    ) {}
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -9,6 +9,9 @@ spring:
           kakao:
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
 
+kakao:
+  rest-api-key: ${KAKAO_CLIENT_ID}
+
 logging:
   level:
     org.springframework.security.oauth2: DEBUG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,7 @@ cloud:
 
 kakao:
   admin-key: ${KAKAO_ADMIN_KEY}
+  rest-api-key: ${KAKAO_CLIENT_ID}
 
 logging:
   level:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -51,6 +51,7 @@ cloud:
 
 kakao:
   admin-key: test-admin-key
+  rest-api-key: test-api-key
 
 springdoc:
   server-url: http://localhost:8080


### PR DESCRIPTION
## 💡 Issue
- Close #250 
  (이슈 번호를 입력하면 PR이 머지될 때 이슈가 자동으로 닫힙니다)

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 기존에 하드코딩으로 처리했던 부분을 외부 API를 불러와 반영합니다
- 사용자의 lat/lon을 기반으로 응답에 현재 위치(시.구)를 텍스트로 표시하고 해당 시/구 단위에 위치한 가게의 디자인만 조회되도록 함

## 🛠️ Changes
- [ ] 서버가 역지오코딩으로 region_1 depth(시/도) + region_2depth(구) 추출
- [ ] 추출한 값을 currentRegion에 현재 위치: ~시 ~구로 응답에 포함
- [ ] DB 조회시 distrct 로 조회

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)
<img width="1177" height="749" alt="스크린샷 2026-02-19 160445" src="https://github.com/user-attachments/assets/f6f3b16f-6edf-45d0-9dfe-eb870964eb4e" />

## ✅ Checklist
- [ ] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] develop 브랜치의 최신 사항을 pull 받았나요?
- [ ] 테스트(빌드)가 성공적으로 통과했나요?