### PR TITLE
[FEAT/#143] 주문서 전달 알림 세팅

### DIFF
--- a/src/main/java/com/example/picknwhip_be/domain/order/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/order/service/command/OrderCommandServiceImpl.java
@@ -42,7 +42,6 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   private final ApplicationEventPublisher publisher;
 
   @Override
-  @Transactional
   public OrderResDTO.OrderCompleteDTO createOrder(Long userId, OrderReqDTO.CreateOrderDTO dto) {
     OrderDraft draft =
         orderDraftRepository

--- a/src/main/java/com/example/picknwhip_be/domain/order/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/example/picknwhip_be/domain/order/service/command/OrderCommandServiceImpl.java
@@ -2,6 +2,8 @@ package com.example.picknwhip_be.domain.order.service.command;
 
 import com.example.picknwhip_be.domain.custom.entity.OrderDraft;
 import com.example.picknwhip_be.domain.custom.repository.OrderDraftRepository;
+import com.example.picknwhip_be.domain.notification.enums.NotificationKind;
+import com.example.picknwhip_be.domain.notification.event.CreateNotificationEvent;
 import com.example.picknwhip_be.domain.order.dto.req.OrderReqDTO;
 import com.example.picknwhip_be.domain.order.dto.res.OrderResDTO;
 import com.example.picknwhip_be.domain.order.entity.DailyShopOrderCounter;
@@ -21,6 +23,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,8 +39,10 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   private final DailyShopOrderCounterRepository counterRepository;
   private final PickupTimeValidator pickupTimeValidator;
   private final OrderHistoryRepository orderHistoryRepository;
+  private final ApplicationEventPublisher publisher;
 
   @Override
+  @Transactional
   public OrderResDTO.OrderCompleteDTO createOrder(Long userId, OrderReqDTO.CreateOrderDTO dto) {
     OrderDraft draft =
         orderDraftRepository
@@ -97,6 +102,15 @@ public class OrderCommandServiceImpl implements OrderCommandService {
       orderItemRepository.saveAll(orderItems);
     }
     orderDraftRepository.delete(draft);
+
+    Long orderId = savedOrder.getId();
+    publisher.publishEvent(
+        new CreateNotificationEvent(
+            userId,
+            NotificationKind.ORDER_SHEET_CHECKING,
+            orderId,
+            savedOrder.getShop().getShopName()));
+
     return OrderResDTO.from(savedOrder);
   }
 


### PR DESCRIPTION
## 💡 Issue
- Close #143 

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련
- 
## 📝 Summary
- 다른 주문 단계별 알림은 사장님 쪽이 구현되지 않은 관계로 주문서 전달 관련 알림만 추가하였습니다.

## 🛠️ Changes
- [x] 주문서 요청 api에 알림 발송 추가

## 📸 Screenshots
(UI 변경 사항이 있거나, API 테스트 결과(Postman 등)가 있다면 첨부해주세요)

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?